### PR TITLE
Fix issue where description is not being set

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -218,7 +218,7 @@ namespace Contentful.Core
 
             var res = await PutAsync(
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/content_types/{contentType.SystemProperties.Id}",
-                ConvertObjectToJsonStringContent(new { name = contentType.Name, displayField = contentType.DisplayField, fields = contentType.Fields }), cancellationToken).ConfigureAwait(false);
+                ConvertObjectToJsonStringContent(new { name = contentType.Name, description = contentType.Description, displayField = contentType.DisplayField, fields = contentType.Fields }), cancellationToken).ConfigureAwait(false);
 
             RemoveVersionHeader();
 


### PR DESCRIPTION
Currently description is not being set on a content type when using the management API to create content types