### PR TITLE
Fix issue where range is treated as a size validator

### DIFF
--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -241,7 +241,7 @@ namespace Contentful.Core.Models.Management
         /// <returns>The object to serialize.</returns>
         public object CreateValidator()
         {
-            return new { size = new { min = Min, max = Max }, message = Message };
+            return new { range = new { min = Min, max = Max }, message = Message };
         }
     }
 


### PR DESCRIPTION
Currently RangeValidators are serializing as SizeValidators when being created.