### PR TITLE
Resolved JTokenType.Null exception and Added missing validators

### DIFF
--- a/Contentful.Core/Configuration/ValidationsJsonConverter.cs
+++ b/Contentful.Core/Configuration/ValidationsJsonConverter.cs
@@ -41,16 +41,16 @@ namespace Contentful.Core.Configuration
             if (jsonObject.TryGetValue("size", out jToken))
             {
                 return new SizeValidator(
-                    jToken["min"] != null ? new int?(int.Parse(jToken["min"].ToString())) : null,
-                    jToken["max"] != null ? new int?(int.Parse(jToken["max"].ToString())) : null,
+                    jToken["min"] != null && jToken["min"].Type != JTokenType.Null  ? new int?(int.Parse(jToken["min"].ToString())) : null,
+                    jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? new int?(int.Parse(jToken["max"].ToString())) : null,
                     jsonObject["message"]?.ToString());
             }
 
             if (jsonObject.TryGetValue("range", out jToken))
             {
                 return new RangeValidator(
-                    jToken["min"] != null ? new int?(int.Parse(jToken["min"].ToString())) : null,
-                    jToken["max"] != null ? new int?(int.Parse(jToken["max"].ToString())) : null,
+                    jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? new int?(int.Parse(jToken["min"].ToString())) : null,
+                    jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? new int?(int.Parse(jToken["max"].ToString())) : null,
                     jsonObject["message"]?.ToString());
             }
 

--- a/Contentful.Core/Configuration/ValidationsJsonConverter.cs
+++ b/Contentful.Core/Configuration/ValidationsJsonConverter.cs
@@ -90,22 +90,43 @@ namespace Contentful.Core.Configuration
                 return new UniqueValidator();
             }
 
-            if (_currentObject.TryGetValue("dateRange", out jToken))
+            if (jsonObject.TryGetValue("dateRange", out jToken))
 			{
 				return new DateRangeValidator(
 					jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? jToken["min"].ToString() : null,
 					jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? jToken["max"].ToString() : null,
-					_currentObject["message"]?.ToString());
+					jsonObject["message"]?.ToString());
 			}
 
-            if (_currentObject.TryGetValue("assetFileSize", out jToken))
+            if (jsonObject.TryGetValue("assetFileSize", out jToken))
 			{
 				return new FileSizeValidator(
 					jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? new int?(int.Parse(jToken["min"].ToString())) : null,
 					jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? new int?(int.Parse(jToken["max"].ToString())) : null,
-					FileSizeUnit.Byte,
-					FileSizeUnit.Byte,
-					_currentObject["message"]?.ToString());
+					SystemFileSizeUnits.Bytes,
+					SystemFileSizeUnits.Bytes,
+					jsonObject["message"]?.ToString());
+			}
+
+            if (jsonObject.TryGetValue("assetImageDimensions", out jToken))
+			{
+				int? minWidth = null;
+				int? maxWidth = null;
+				int? minHeight = null;
+				int? maxHeight = null;
+				if (jToken["width"] != null)
+				{
+					JToken width = jToken["width"];
+					minWidth = width["min"] != null && width["min"].Type != JTokenType.Null ? new int?(int.Parse(width["min"].ToString())) : null;
+					maxWidth = width["max"] != null && width["max"].Type != JTokenType.Null ? new int?(int.Parse(width["max"].ToString())) : null;
+				}
+				if (jToken["height"] != null)
+				{
+					JToken height = jToken["height"];
+					minHeight = height["min"] != null && height["min"].Type != JTokenType.Null ? new int?(int.Parse(height["min"].ToString())) : null;
+					maxHeight = height["max"] != null && height["max"].Type != JTokenType.Null ? new int?(int.Parse(height["max"].ToString())) : null;
+				}
+				return new ImageSizeValidator(minWidth, maxWidth, minHeight, maxHeight, jsonObject["message"]?.ToString());
 			}
 
             return Activator.CreateInstance(objectType);

--- a/Contentful.Core/Configuration/ValidationsJsonConverter.cs
+++ b/Contentful.Core/Configuration/ValidationsJsonConverter.cs
@@ -89,6 +89,13 @@ namespace Contentful.Core.Configuration
             {
                 return new UniqueValidator();
             }
+            if (_currentObject.TryGetValue("dateRange", out jToken))
+			{
+				return new DateRangeValidator(
+					jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? jToken["min"].ToString() : null,
+					jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? jToken["max"].ToString() : null,
+					_currentObject["message"]?.ToString());
+			}
 
             return Activator.CreateInstance(objectType);
         }

--- a/Contentful.Core/Configuration/ValidationsJsonConverter.cs
+++ b/Contentful.Core/Configuration/ValidationsJsonConverter.cs
@@ -89,11 +89,22 @@ namespace Contentful.Core.Configuration
             {
                 return new UniqueValidator();
             }
+
             if (_currentObject.TryGetValue("dateRange", out jToken))
 			{
 				return new DateRangeValidator(
 					jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? jToken["min"].ToString() : null,
 					jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? jToken["max"].ToString() : null,
+					_currentObject["message"]?.ToString());
+			}
+
+            if (_currentObject.TryGetValue("assetFileSize", out jToken))
+			{
+				return new FileSizeValidator(
+					jToken["min"] != null && jToken["min"].Type != JTokenType.Null ? new int?(int.Parse(jToken["min"].ToString())) : null,
+					jToken["max"] != null && jToken["max"].Type != JTokenType.Null ? new int?(int.Parse(jToken["max"].ToString())) : null,
+					FileSizeUnit.Byte,
+					FileSizeUnit.Byte,
 					_currentObject["message"]?.ToString());
 			}
 

--- a/Contentful.Core/Models/Location.cs
+++ b/Contentful.Core/Models/Location.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Contentful.Core.Models
+{
+    /// <summary>
+    /// Represents a location field in a <seealso cref="Space"/>. 
+    /// </summary>
+    public class Location
+    {
+        /// <summary>
+        /// The latitude of the location.
+        /// </summary>
+        public double Lat { get; set; }
+
+        /// <summary>
+        /// The longitude of the location.
+        /// </summary>
+        public double Lon { get; set; }
+    }
+}

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -302,6 +302,7 @@ namespace Contentful.Core.Models.Management
             return new { unique = true };
         }
     }
+
     /// <summary>
     /// Represents a validator that ensures that the field value is within a certain date range.
     /// </summary>  
@@ -362,6 +363,59 @@ namespace Contentful.Core.Models.Management
 		public object CreateValidator()
 		{
 			return new { dateRange = new { min = _min, max = _max }, message = this.Message };
+		}
+	}
+
+    /// <summary>
+    /// Represents a validator that ensures that the media file size is within a certain size range.
+    /// </summary>      
+    public class FileSizeValidator : IFieldValidator
+	{
+		protected const int BYTES_IN_KB = 1024;
+		protected const int BYTES_IN_MB = 1048576;
+		/// <summary>
+		/// The minimum allowed size of the file.
+		/// </summary>
+		public int? Min { get; set; }
+
+		/// <summary>
+		/// The maximum allowed size of the file.
+		/// </summary>
+		public int? Max { get; set; }
+		/// <summary>
+		/// The custom error message that should be displayed.
+		/// </summary>
+		public string Message { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of <see cref="T:Contentful.Essential.Models.Management.FileSizeValidator" />.
+		/// </summary>
+		/// <param name="min">The minimum size of the file.</param>
+		/// <param name="max">The maximum size of the file.</param>
+		/// <param name="minUnit">The unit measuring the minimum file size.</param>
+		/// <param name="maxUnit">The unit measuring the maximum file size.</param>
+		/// <param name="message">The custom error message for this validation.</param>
+		public FileSizeValidator(int? min, int? max, string minUnit = SystemFileSizeUnits.Bytes, string maxUnit = SystemFileSizeUnits.Bytes, string message = null)
+		{
+			this.Min = GetCalculatedByteSize(min, minUnit);
+			this.Max = GetCalculatedByteSize(max, maxUnit);
+			this.Message = message;
+		}
+		public object CreateValidator()
+		{
+			return new { assetFileSize = new { min = this.Min, max = this.Max }, message = this.Message };
+		}
+
+		protected virtual int? GetCalculatedByteSize(int? value, string unit)
+		{
+			if (value != null)
+			{
+				if (unit == SystemFileSizeUnits.KB)
+					value = value * 1000;
+				if (unit == SystemFileSizeUnits.MB)
+					value = value * 1048576;
+			}
+			return value;
 		}
 	}
 }

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -349,7 +349,7 @@ namespace Contentful.Core.Models.Management
 
 
 		/// <summary>
-		/// Initializes a new instance of <see cref="T:Contentful.Essential.Models.Management.DateRangeValidator" />.
+		/// Initializes a new instance of <see cref="DateRangeValidator"/>.
 		/// </summary>
 		/// <param name="minWidth">The minimum date of the range.</param>
 		/// <param name="maxWidth">The maximum date of the range.</param>
@@ -388,7 +388,7 @@ namespace Contentful.Core.Models.Management
 		public string Message { get; set; }
 
 		/// <summary>
-		/// Initializes a new instance of <see cref="T:Contentful.Essential.Models.Management.FileSizeValidator" />.
+		/// Initializes a new instance of <see cref="FileSizeValidator" />.
 		/// </summary>
 		/// <param name="min">The minimum size of the file.</param>
 		/// <param name="max">The maximum size of the file.</param>

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -302,5 +302,66 @@ namespace Contentful.Core.Models.Management
             return new { unique = true };
         }
     }
+    /// <summary>
+    /// Represents a validator that ensures that the field value is within a certain date range.
+    /// </summary>  
+    public class DateRangeValidator : IFieldValidator
+	{
+		protected string _min;
 
+		/// <summary>
+		/// The minimum allowed date.
+		/// </summary>
+		public DateTime? Min
+		{
+			get
+			{
+                DateTime parsed;
+                if (DateTime.TryParse(_min, out parsed))
+                    return (DateTime?)parsed;
+
+                return null;
+			}
+		}
+
+		protected string _max;
+
+		/// <summary>
+		/// The maximum allowed date.
+		/// </summary>
+		public DateTime? Max
+		{
+			get
+			{
+				 DateTime parsed;
+                if (DateTime.TryParse(_max, out parsed))
+                    return (DateTime?)parsed;
+
+                return null;
+			}
+		}
+
+		/// <summary>
+		/// The custom error message that should be displayed.
+		/// </summary>
+		public string Message { get; set; }
+
+
+		/// <summary>
+		/// Initializes a new instance of <see cref="T:Contentful.Essential.Models.Management.DateRangeValidator" />.
+		/// </summary>
+		/// <param name="minWidth">The minimum date of the range.</param>
+		/// <param name="maxWidth">The maximum date of the range.</param>
+		/// <param name="message">The custom error message for this validation.</param>
+		public DateRangeValidator(string min, string max, string message = null)
+		{
+			_min = min;
+			_max = max;
+			this.Message = message;
+		}
+		public object CreateValidator()
+		{
+			return new { dateRange = new { min = _min, max = _max }, message = this.Message };
+		}
+	}
 }

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -418,4 +418,57 @@ namespace Contentful.Core.Models.Management
 			return value;
 		}
 	}
+    
+    /// <summary>
+    /// Represents a validator that ensures that the image dimensions are within a certain range.
+    /// </summary>   
+    public class ImageSizeValidator : IFieldValidator
+	{
+		/// <summary>
+		/// The minimum allowed width of the image (in px).
+		/// </summary>
+		public int? MinWidth { get; set; }
+
+		/// <summary>
+		/// The maximum allowed width of the image (in px).
+		/// </summary>
+		public int? MaxWidth { get; set; }
+		/// <summary>
+		/// The minimum allowed height of the iamge (in px).
+		/// </summary>
+		int? MinHeight { get; set; }
+
+		/// <summary>
+		/// The maximum allowed height of the image (in px).
+		/// </summary>
+		public int? MaxHeight { get; set; }
+
+		/// <summary>
+		/// The custom error message that should be displayed.
+		/// </summary>
+		public string Message { get; set; }
+
+
+		/// <summary>
+		/// Initializes a new instance of <see cref="ImageSizeValidator" />.
+		/// </summary>
+		/// <param name="minWidth">The minimum width of the image.</param>
+		/// <param name="maxWidth">The maximum width of the image.</param>
+		/// <param name="minHeight">The minimum height of the image.</param>
+		/// <param name="maxHeight">The maximum height of the image.</param>
+		/// <param name="message">The custom error message for this validation.</param>
+		public ImageSizeValidator(int? minWidth, int? maxWidth, int? minHeight, int? maxHeight, string message = null)
+		{
+			this.MinWidth = minWidth;
+			this.MaxWidth = maxWidth;
+			this.MinHeight = minHeight;
+			this.MaxHeight = maxHeight;
+			this.Message = message;
+		}
+
+		public object CreateValidator()
+		{
+			return new { assetImageDimensions = new { width = new { min = this.MinWidth, max = this.MaxWidth }, height = new { min = this.MinHeight, max = this.MaxHeight } }, message = this.Message };
+		}
+	}
 }

--- a/Contentful.Core/Models/Management/SystemFileSizeUnits.cs
+++ b/Contentful.Core/Models/Management/SystemFileSizeUnits.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Contentful.Core.Models.Management
+{
+    /// <summary>
+    /// Represents the different units available for <see cref="FileSizeValidator"/>.
+    /// </summary>
+    public class SystemFileSizeUnits
+    {
+        /// <summary>
+        /// Measure the file in bytes.
+        /// </summary>
+        public const string Bytes = "Bytes";
+
+        /// <summary>
+        /// Measure the file in KB.
+        /// </summary>
+        public const string KB = "KB";
+
+        /// <summary>
+        /// Measure the file in MB.
+        /// </summary>
+        public const string MB = "MB";
+    }
+}


### PR DESCRIPTION
When trying to parse the Json of the size and range validators, if the JTokenType is null (e.g. the json looks something like this: { size: { min: null, max: 50 } }, there would be an exception thrown by the int.Parse. I added a check for the JTokenType before executing the int.Parse.

I also noticed when trying to get a content type for which one of the missing validators was defined, there would be an exception thrown from the
`return Activator.CreateInstance(objectType);`
since you cannot create a type of an interface, in this case IFieldValidator.