### PR TITLE
Remove JsonProperty Mapping for "file"

### DIFF
--- a/Contentful.Core/Models/Asset.cs
+++ b/Contentful.Core/Models/Asset.cs
@@ -45,7 +45,6 @@ namespace Contentful.Core.Models
         /// <summary>
         /// Information about the file in respective language.
         /// </summary>
-        [JsonProperty("file")]
         public Dictionary<string, File> FilesLocalized { get; set; }
     }
 }


### PR DESCRIPTION
This is an inconsistency as you either have all the fields mapped to the localized models like the following example, or you remove the JsonProperty as I did. This is creating an issue for me as ALL my fields are localize and I cannot directly map the `SynedAsset` to the `Asset`

```
    public class Asset : IContentfulResource
    {
        /// <summary>
        /// Common system managed metadata properties.
        /// </summary>
        [JsonProperty("sys")]
        public SystemProperties SystemProperties { get; set; }

        /// <summary>
        /// The description of the asset.
        /// </summary>
        public string Description { get; set; }

        /// <summary>
        /// The title of the asset.
        /// </summary>
        public string Title { get; set; }

        /// <summary>
        /// Encapsulates information about the binary file of the asset.
        /// </summary>
        public File File { get; set; }

        /// <summary>
        /// The titles of the asset per locale.
        /// </summary>
        [JsonProperty("title")]
        public Dictionary<string, string> TitleLocalized { get; set; }

        /// <summary>
        /// The descriptions of the asset per locale.
        /// </summary>
        [JsonProperty("description")]
        public Dictionary<string, string> DescriptionLocalized { get; set; }

        /// <summary>
        /// Information about the file in respective language.
        /// </summary>
        [JsonProperty("file")]
        public Dictionary<string, File> FilesLocalized { get; set; }
    }
```

As currently only file is mapped to the localization property which is not really consistent.