### PR TITLE
Update README.md file with a couple changes to make it looks better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ This is the .NET SDK for [Contentful's][1] Content Delivery and Content Manageme
 
 ## Setup
 
-We recommend you use the NuGet package manager to add Contentful to your .Net application using the following command in your NuGet package manager console.
+We recommend you use the NuGet Package Manager to add Contentful Client Library to your .NET Application using one of the following options:
 
-```powershell
-PM> Install-Package contentful.csharp
-```
+- In Visual Studio, open Package Manager Console window and run the following command:
+
+  ```powershell
+  PM> Install-Package contentful.csharp
+  ```
+
+- In a command-line, run the following .NET CLI command:
+
+  ```console
+  > dotnet add package contentful.csharp
+  ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![build status](https://travis-ci.com/contentful/contentful.net.svg?token=Pyo2hEQ4sLp3x19cTNf6&branch=master)
 
-# Contentful Client Library for .NET
+# contentful.net
 
 [https://www.contentful.com][1] is a content management platform for web applications, mobile apps and connected devices. It allows you to create, edit & manage content in the cloud and publish it anywhere via powerful API. Contentful offers tools for managing editorial teams and enabling cooperation between organizations.
 
@@ -8,7 +8,7 @@ This is the .NET SDK for [Contentful's][1] Content Delivery and Content Manageme
 
 ## Setup
 
-We recommend you use the NuGet Package Manager to add Contentful Client Library to your .NET Application using one of the following options:
+We recommend you use the NuGet Package Manager to add the SDK to your .NET Application using one of the following options:
 
 - In Visual Studio, open Package Manager Console window and run the following command:
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is the .NET SDK for [Contentful's][1] Content Delivery and Content Manageme
 
 We recommend you use the NuGet package manager to add Contentful to your .Net application using the following command in your NuGet package manager console.
 
-```csharp
-Install-Package contentful.csharp -prerelease
+```powershell
+PM> Install-Package contentful.csharp
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![build status](https://travis-ci.com/contentful/contentful.net.svg?token=Pyo2hEQ4sLp3x19cTNf6&branch=master)
 
-# contentful.net
+# Contentful Client Library for .NET
 
 [https://www.contentful.com][1] is a content management platform for web applications, mobile apps and connected devices. It allows you to create, edit & manage content in the cloud and publish it anywhere via powerful API. Contentful offers tools for managing editorial teams and enabling cooperation between organizations.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Console.WriteLine(entry.Fields.productName.ToString()); // => Contentful
 Normally you serialize this response into your own class instead of the generic `Entry<>` type. You can do this by providing a suitable type to seralize into. Take the following class as an example:
 
 ```csharp
-public class Product {
+public class Product
+{
     public string ProductName { get; set; }
     public string Price { get; set; }
     public string Description { get; set; }
@@ -99,7 +100,8 @@ You can then use the client to, for example, create a content type.
 
 ```csharp
 var contentType = new ContentType();
-contentType.SystemProperties = new SystemProperties() {
+contentType.SystemProperties = new SystemProperties()
+{
     Id = "new-content-type"
 };
 contentType.Name = "New contenttype";


### PR DESCRIPTION
Changes:

1. Since there is RTM version `1.0.0`, I removed the `-prerelease` argument from Package Manager command. 
2. Since the library is targeting .NET Standard, I added second option to install the NuGet package via .NET CLI.
3. To make all code example consistent, I placed open brace on a new line.
4. Updated project's name to `Contentful Client Library` make it clear. If you don't like it, maybe `Contentful SDK for .NET` then.