### PR TITLE
Add IContentTypeResolver to IContentfulClient

### DIFF
--- a/Contentful.Core/IContentfulClient.cs
+++ b/Contentful.Core/IContentfulClient.cs
@@ -7,6 +7,7 @@ using Contentful.Core.Models;
 using Contentful.Core.Search;
 using System.Threading;
 using Newtonsoft.Json;
+using Contentful.Core.Configuration;
 
 namespace Contentful.Core
 {
@@ -15,6 +16,11 @@ namespace Contentful.Core
     /// </summary>
     public interface IContentfulClient
     {
+        /// <summary>
+        /// Gets or sets the resolver used when resolving entries to typed objects.
+        /// </summary>
+        IContentTypeResolver ContentTypeResolver { get; set; }
+
         /// <summary>
         /// Gets or sets the settings that should be used for deserialization.
         /// </summary>


### PR DESCRIPTION
It would be good to have the IContentTypeResolver on the the IContentfulClient interface so that you can inject IContentClient with DI and not have to deal with the implementation class.