### PR TITLE
Fix repository URL for Source Code Link feature.

### DIFF
--- a/Contentful.AspNetCore/Contentful.AspNetCore.csproj
+++ b/Contentful.AspNetCore/Contentful.AspNetCore.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/contentful/contentful.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/contentful/contentful.net/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/contentful/contentful.net</RepositoryUrl>
+    <RepositoryUrl>https://github.com/contentful/contentful.net</RepositoryUrl>
     <Version>3.3.4</Version>
     <AssemblyVersion>3.3.4.0</AssemblyVersion>
   </PropertyGroup>

--- a/Contentful.Core/Contentful.Core.csproj
+++ b/Contentful.Core/Contentful.Core.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/contentful/contentful.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/contentful/contentful.net/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/contentful/contentful.net</RepositoryUrl>
+    <RepositoryUrl>https://github.com/contentful/contentful.net</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
The [nuget.org](https://www.nuget.org/) doesn't current show the link `Source Code` for NuGet package `contentful.csharp` for [Source Code Link](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html) feature.

![nuget](https://user-images.githubusercontent.com/2487951/44764982-4ecd5380-ab07-11e8-9f6d-42b1a2565bf5.png)

The reason is because of the incorrect value in the element `RepositoryUrl`. It starts with `git://` instead of `https://`.

After merging the fix, you should re-upload the package to bring updated `nuspec`.

![nuget-sourcecode](https://user-images.githubusercontent.com/2487951/44765069-ddda6b80-ab07-11e8-8336-846b32f99c5b.png)
