### PR TITLE
Ensure all rich text node types have a data property

### DIFF
--- a/Contentful.Core/Models/AuthoringModels.cs
+++ b/Contentful.Core/Models/AuthoringModels.cs
@@ -12,6 +12,11 @@ namespace Contentful.Core.Models
     public class Document
     {
         /// <summary>
+        /// The data for the document node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
+        /// <summary>
         /// The type of the node.
         /// </summary>
         public string NodeType { get; set; }
@@ -27,6 +32,11 @@ namespace Contentful.Core.Models
     /// </summary>
     public class Text : IContent
     {
+        /// <summary>
+        /// The data for the text node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
         /// <summary>
         /// The type of the node.
         /// </summary>
@@ -83,7 +93,7 @@ namespace Contentful.Core.Models
     /// <summary>
     /// Represents a mark for a text node.
     /// </summary>
-    public class Mark : IContent
+    public class Mark
     {
         /// <summary>
         /// The type of mark.
@@ -96,6 +106,11 @@ namespace Contentful.Core.Models
     /// </summary>
     public class Paragraph : IContent
     {
+        /// <summary>
+        /// The data for the paragraph node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
         /// <summary>
         /// The type of node.
         /// </summary>
@@ -112,6 +127,11 @@ namespace Contentful.Core.Models
     /// </summary>
     public class Heading : IContent
     {
+        /// <summary>
+        /// The data for the heading node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
         /// <summary>
         /// The type of node.
         /// </summary>
@@ -161,6 +181,11 @@ namespace Contentful.Core.Models
     public class List : IContent
     {
         /// <summary>
+        /// The data for the list node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
+        /// <summary>
         /// The type of node.
         /// </summary>
         public string NodeType { get; set; }
@@ -176,6 +201,11 @@ namespace Contentful.Core.Models
     /// </summary>
     public class ListItem : IContent
     {
+        /// <summary>
+        /// The data for the list item node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
         /// <summary>
         /// The type of node.
         /// </summary>
@@ -193,6 +223,11 @@ namespace Contentful.Core.Models
     public class Quote : IContent
     {
         /// <summary>
+        /// The data for the quote node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
+        /// <summary>
         /// The type of node.
         /// </summary>
         public string NodeType { get; set; }
@@ -208,6 +243,11 @@ namespace Contentful.Core.Models
     /// </summary>
     public class HorizontalRuler : IContent
     {
+        /// <summary>
+        /// The data for the heading node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
         /// <summary>
         /// The type of node.
         /// </summary>
@@ -316,9 +356,21 @@ namespace Contentful.Core.Models
     public class CustomNode : IContent
     {
         /// <summary>
+        /// The data for the custom node.
+        /// </summary>
+        public EmptyNodeData Data { get; set; }
+
+        /// <summary>
         /// The JSON data of the node.
         /// </summary>
         public JObject JObject { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an empty node data structure for nodes where the data property is empty.
+    /// </summary>
+    public class EmptyNodeData
+    {
     }
 
     /// <summary>


### PR DESCRIPTION
@Roblinde I am looking at adding proper support for the rich text field, but there are changes required beyond just the missing `Data` property discussed in #169. 

I am therefore opening up this draft pull request as a starting point for the discussion.

On a high level, I would like to make the following changes:

1. Remove the setter of the `NodeType` property on all the different node types. This value is required to be sent to the Contentful Management API, but I believe the user should not be responsible for having to know this. Each class should supply this value itself, e.g.

   ```
    public class Heading : IContent
    {
        public EmptyNodeData Data { get; set; }

        public string NodeType => $"heading-{HeadingSize}";

        public int HeadingSize { get; set; }
    }
   ```
1. Many node types are missing. For example, `embedded-entry-block`, `embedded-entry-inline`, `hyperlink` etc.
1. Speaking of the missing node types; Do you have some sort of documentation somewhere of **all** the possible node types? Some sort of schema perhaps?
1. We would probably need to create some sort of customer JSON.NET serializer / deserializer to handle deserialization of the JSON for the rich text structure to the correct classes (since the node type is contained in the `nodeType` attribute of each the JSON element

There are probably many more things to be discovered as I dive deeper. Have you give proper support for rich text any thought yet? 

Would like to hear your feedback 
