### PR TITLE
added deserialization support for validation types that use rich text

### DIFF
--- a/Contentful.Core.Tests/ContentfulManagementClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulManagementClientTests.cs
@@ -218,12 +218,21 @@ namespace Contentful.Core.Tests
             //Arrange
             _handler.Response = GetResponseFromFile(@"ContenttypesCollectionManagement.json");
             //Act
-            var res = await _client.GetContentTypes();
+            try
+            {
+                var res = await _client.GetContentTypes();
+                //Assert
+                Assert.Equal(5, res.Count());
+                Assert.Equal("someName", res.First().Name);
+                Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
+            }
+            catch (Exception ex)
+            {
 
-            //Assert
-            Assert.Equal(4, res.Count());
-            Assert.Equal("someName", res.First().Name);
-            Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
+                Console.WriteLine(ex);
+            }
+        
+         
         }
 
         [Fact]
@@ -425,7 +434,7 @@ namespace Contentful.Core.Tests
             var res = await _client.GetActivatedContentTypes();
 
             //Assert
-            Assert.Equal(4, res.Count());
+            Assert.Equal(5, res.Count());
             Assert.Equal($"https://api.contentful.com/spaces/666/public/content_types", requestUrl);
             Assert.Equal("someName", res.First().Name);
             Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
@@ -3075,7 +3084,7 @@ namespace Contentful.Core.Tests
             var res = await client.GetContentTypes();
 
             //Assert
-            Assert.Equal(4, res.Count());
+            Assert.Equal(5, res.Count());
             Assert.Equal("someName", res.First().Name);
             Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
             Assert.Equal("https://api.contentful.com/spaces/564/environments/special/content_types", path);

--- a/Contentful.Core.Tests/ContentfulManagementClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulManagementClientTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -56,12 +55,13 @@ namespace Contentful.Core.Tests
             Assert.Equal("Bearer 564", authHeader);
             Assert.StartsWith($"sdk contentful.csharp/{version}", userAgent);
         }
-        
+
         [Fact]
         public async Task CreateContentTypeShouldSerializeRequestCorrectly()
         {
             //Arrange
-            _handler.Response = new HttpResponseMessage() {
+            _handler.Response = new HttpResponseMessage()
+            {
                 Content = new StringContent("{}")
             };
             var contentType = new ContentType()
@@ -218,21 +218,11 @@ namespace Contentful.Core.Tests
             //Arrange
             _handler.Response = GetResponseFromFile(@"ContenttypesCollectionManagement.json");
             //Act
-            try
-            {
-                var res = await _client.GetContentTypes();
-                //Assert
-                Assert.Equal(5, res.Count());
-                Assert.Equal("someName", res.First().Name);
-                Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
-            }
-            catch (Exception ex)
-            {
-
-                Console.WriteLine(ex);
-            }
-        
-         
+            var res = await _client.GetContentTypes();
+            //Assert
+            Assert.Equal(5, res.Count());
+            Assert.Equal("someName", res.First().Name);
+            Assert.Equal(8, (res.First().Fields.First().Validations.First() as SizeValidator).Max);
         }
 
         [Fact]
@@ -350,7 +340,7 @@ namespace Contentful.Core.Tests
         public async Task ActivatingContentTypeShouldThrowForEmptyId()
         {
             //Arrange
-            
+
             //Act
             var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await _client.ActivateContentType("", 34));
 
@@ -1451,7 +1441,7 @@ namespace Contentful.Core.Tests
             _handler.Responses.Enqueue(GetResponseFromFile(@"SampleAssetManagementUnprocessed.json"));
             _handler.Responses.Enqueue(GetResponseFromFile(@"SampleAssetManagementUnprocessed.json"));
             _handler.Responses.Enqueue(GetResponseFromFile(@"SampleAssetManagement.json"));
-            
+
             //Act
             var res = await _client.ProcessAssetUntilCompleted("123", 3, "en-US");
 
@@ -1897,7 +1887,7 @@ namespace Contentful.Core.Tests
             //Assert
             Assert.Equal("Testhook", res.Name);
             Assert.Equal("https://robertlinde.se/", res.Url);
-            Assert.Collection(res.Topics, 
+            Assert.Collection(res.Topics,
                 (t) => Assert.Equal("Asset.archive", t),
                 (t) => Assert.Equal("Asset.unarchive", t),
                 (t) => Assert.Equal("ContentType.create", t),
@@ -1906,7 +1896,7 @@ namespace Contentful.Core.Tests
                 (t) => Assert.Equal("Entry.unpublish", t));
             Assert.Collection(res.Filters,
                 (f) => Assert.IsType(typeof(EqualsConstraint), f),
-                (f) => Assert.IsType(typeof(InConstraint),(f as NotConstraint).ConstraintToInvert)
+                (f) => Assert.IsType(typeof(InConstraint), (f as NotConstraint).ConstraintToInvert)
                 );
             Assert.Collection(res.Headers, (h) => { Assert.Equal("bob", h.Key); Assert.Equal("uncle", h.Value); });
         }
@@ -2224,7 +2214,7 @@ namespace Contentful.Core.Tests
                 SystemProperties = new SystemProperties()
             };
             role.SystemProperties.Id = id;
-            
+
             //Act
             var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await _client.UpdateRole(role));
 
@@ -2361,7 +2351,7 @@ namespace Contentful.Core.Tests
         {
             //Arrange
             _handler.Response = GetResponseFromFile(@"SampleSnapshot.json");
-            
+
             //Act
             var res = await _client.GetSnapshotForEntry("123", "wed");
 
@@ -2984,8 +2974,9 @@ namespace Contentful.Core.Tests
             var res = await _client.GetAllManagementTokens();
 
             //Assert
-            
-            Assert.Collection(res, (c) => {
+
+            Assert.Collection(res, (c) =>
+            {
                 Assert.Equal(SystemManagementScopes.Manage, c.Scopes.First());
                 Assert.Equal(1, c.Scopes.Count);
                 Assert.Null(c.Token);
@@ -3056,7 +3047,7 @@ namespace Contentful.Core.Tests
             var contentSet = "";
             _handler.VerifyRequest = async (HttpRequestMessage request) =>
             {
-                 contentSet = await (request.Content as StringContent).ReadAsStringAsync();
+                contentSet = await (request.Content as StringContent).ReadAsStringAsync();
             };
 
             //Act
@@ -3603,7 +3594,7 @@ namespace Contentful.Core.Tests
             };
 
             //Act
-            var res = await client.CreateOrUpdateAsset(new ManagementAsset { SystemProperties = new SystemProperties { Id="325" } });
+            var res = await client.CreateOrUpdateAsset(new ManagementAsset { SystemProperties = new SystemProperties { Id = "325" } });
 
             //Assert
             Assert.Equal("https://api.contentful.com/spaces/564/environments/special/assets/325", path);
@@ -3888,7 +3879,7 @@ namespace Contentful.Core.Tests
             };
 
             //Act
-           await client.DeleteExtension("sbth");
+            await client.DeleteExtension("sbth");
 
             //Assert
             Assert.Equal("https://api.contentful.com/spaces/564/environments/special/extensions/sbth", path);
@@ -3899,19 +3890,21 @@ namespace Contentful.Core.Tests
         {
             //Arrange
             _handler.Response = GetResponseFromFile(@"EnvironmentsCollection.json");
-            
+
             //Act
             var res = await _client.GetEnvironments();
 
             //Assert
             Assert.Equal(2, res.Total);
             Assert.Collection(res,
-                (e) => {
+                (e) =>
+                {
                     Assert.Equal("queued", e.SystemProperties.Status.SystemProperties.Id);
                     Assert.Equal("Link", e.SystemProperties.Status.SystemProperties.Type);
                     Assert.Equal("Status", e.SystemProperties.Status.SystemProperties.LinkType);
                 },
-                (e) => {
+                (e) =>
+                {
                     Assert.Equal("queued", e.SystemProperties.Status.SystemProperties.Id);
                     Assert.Equal("Link", e.SystemProperties.Status.SystemProperties.Type);
                     Assert.Equal("Status", e.SystemProperties.Status.SystemProperties.LinkType);
@@ -4051,22 +4044,26 @@ namespace Contentful.Core.Tests
 
             //Assert
             Assert.Collection(res,
-                    (t) => {
+                    (t) =>
+                    {
                         Assert.Equal("07/15/2018 00:00:00", t.StartDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Null(t.EndDate);
                         Assert.Equal("4", t.SystemProperties.Id);
                     },
-                    (t) => {
+                    (t) =>
+                    {
                         Assert.Equal("06/15/2018 00:00:00", t.StartDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("07/14/2018 00:00:00", t.EndDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("3", t.SystemProperties.Id);
                     },
-                    (t) => {
+                    (t) =>
+                    {
                         Assert.Equal("05/15/2018 00:00:00", t.StartDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("06/14/2018 00:00:00", t.EndDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("2", t.SystemProperties.Id);
                     },
-                    (t) => {
+                    (t) =>
+                    {
                         Assert.Equal("04/15/2018 00:00:00", t.StartDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("05/14/2018 00:00:00", t.EndDate.Value.ToString(CultureInfo.InvariantCulture));
                         Assert.Equal("1", t.SystemProperties.Id);
@@ -4231,7 +4228,7 @@ namespace Contentful.Core.Tests
         {
             //Arrange
             _handler.Response = GetResponseFromFile(@"SampleOrgMembershipsCollection.json");
-            
+
             var contentSet = "";
             var url = "";
             var method = HttpMethod.Trace;
@@ -4243,7 +4240,7 @@ namespace Contentful.Core.Tests
             };
 
             //Act
-            var res = await _client.UpdateOrganizationMembership("bob",id,"orgolonio");
+            var res = await _client.UpdateOrganizationMembership("bob", id, "orgolonio");
 
             //Assert
             Assert.Equal(HttpMethod.Put, method);

--- a/Contentful.Core.Tests/JsonFiles/ContenttypesCollectionManagement.json
+++ b/Contentful.Core.Tests/JsonFiles/ContenttypesCollectionManagement.json
@@ -2,7 +2,7 @@
   "sys": {
     "type": "Array"
   },
-  "total": 4,
+  "total": 5,
   "skip": 0,
   "limit": 100,
   "items": [
@@ -505,6 +505,135 @@
           "localized": false,
           "required": false,
           "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "u4vv676b8z52"
+          }
+        },
+        "id": "journeyArticle",
+        "type": "ContentType",
+        "createdAt": "2019-06-19T14:40:59.804Z",
+        "updatedAt": "2019-07-12T17:50:36.860Z",
+        "environment": {
+          "sys": {
+            "id": "minimal",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 33,
+        "publishedAt": "2019-07-12T17:50:36.860Z",
+        "firstPublishedAt": "2019-06-19T14:41:00.312Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "0ZMx32pBrMAwzlN3M6lytc"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "66x1gzWGQ4DHYrBfTsdJEG"
+          }
+        },
+        "publishedCounter": 17,
+        "version": 34,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "66x1gzWGQ4DHYrBfTsdJEG"
+          }
+        }
+      },
+      "displayField": "pageTitle",
+      "name": "Journey Article",
+      "description": "Article format for journeys. ",
+      "fields": [
+        {
+          "id": "articleCopy",
+          "name": "Article Copy",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+      
+        {
+          "id": "contactInformation",
+          "name": "Contact Information",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            },
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline"
+              ],
+              "message": "Only bold, italic, and underline marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, and heading 6 nodes are allowed"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "articleSources",
+          "name": "Article Sources",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            },
+            {
+              "enabledNodeTypes": [
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-entry-block",
+                "embedded-asset-block",
+                "hyperlink",
+                "entry-hyperlink",
+                "embedded-entry-inline"
+              ],
+              "message": "Only ordered list, unordered list, horizontal rule, quote, block entry, asset, link to Url, link to entry, and inline entry nodes are allowed"
+            }
+          ],
           "disabled": false,
           "omitted": false
         }

--- a/Contentful.Core/Configuration/ValidationsJsonConverter.cs
+++ b/Contentful.Core/Configuration/ValidationsJsonConverter.cs
@@ -42,6 +42,7 @@ namespace Contentful.Core.Configuration
                     jsonObject["message"]?.ToString());
             }
 
+
             if (jsonObject.TryGetValue("range", out jToken))
             {
                 return new RangeValidator(
@@ -143,6 +144,21 @@ namespace Contentful.Core.Configuration
                 }
 
                 return validator;
+            }
+
+            if (jsonObject.TryGetValue("enabledMarks", out jToken))
+            {
+                var types = jToken.Values<string>();
+                return new EnabledMarksValidator(types.Select(c => (EnabledMarkRestrictions)Enum.Parse(typeof(EnabledMarkRestrictions), c, true)),
+                    jsonObject["message"]?.ToString());
+            }
+
+
+            if (jsonObject.TryGetValue("enabledNodeTypes", out jToken))
+            {
+                var types = jToken.Values<string>();
+                return new EnabledNodeTypesValidator(types.Select(c => EnabledNodeTypesValidator.toEnum(c)),
+                    jsonObject["message"]?.ToString());
             }
 
             return Activator.CreateInstance(objectType);

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -3,10 +3,8 @@ using Contentful.Core.Search;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Contentful.Core.Models.Management
 {
@@ -21,6 +19,173 @@ namespace Contentful.Core.Models.Management
         /// </summary>
         /// <returns>The object to serialize.</returns>
         object CreateValidator();
+    }
+
+
+
+    public enum EnabledNodeTypeRestrictions
+    {
+        [Description("heading-1")]
+        BLOCKS_HEADING_1,
+        [Description("heading-2")]
+        BLOCKS_HEADING_2,
+        [Description("heading-3")]
+        BLOCKS_HEADING_3,
+        [Description("heading-4")]
+        BLOCKS_HEADING_4,
+        [Description("heading-5")]
+        BLOCKS_HEADING_5,
+        [Description("heading-6")]
+        BLOCKS_HEADING_6,
+        [Description("paragraph")]
+        BLOCKS_PARAGRAPH,
+        [Description("blockquote")]
+        BLOCKS_QUOTE,
+        [Description("hr")]
+        BLOCKS_HR,
+        [Description("ordered-list")]
+        BLOCKS_OL_LIST,
+        [Description("unordered-list")]
+        BLOCKS_UL_LIST,
+        [Description("list-item")]
+        BLOCKS_LIST_ITEM,
+        [Description("embedded-entry-block")]
+        BLOCKS_EMBEDDED_ENTRY,
+        [Description("embedded-asset-block")]
+        BLOCKS_EMBEDDED_ASSET,
+        [Description("embedded-entry-inline")]
+        INLINES_EMBEDDED_ENTRY,
+        [Description("hyperlink")]
+        INLINES_HYPERLINK,
+        [Description("asset-hyperlink")]
+        INLINES_ASSET_HYPERLINK,
+        [Description("entry-hyperlink")]
+        INLINES_ENTRY_HYPERLINK
+    }
+
+
+    public enum EnabledMarkRestrictions
+    {
+        bold,
+        italic,
+        underline,
+        code
+    }
+
+    /// <summary>
+    /// Represents a validator that validates the EnabledMarks property.
+    /// </summary>
+    /// <summary>
+    /// Represents a validator that validates the Enabled marks />
+    /// </summary>
+    public class EnabledNodeTypesValidator : IFieldValidator
+    {
+
+        public static Dictionary<string, EnabledNodeTypeRestrictions> map;
+
+        static EnabledNodeTypesValidator()
+        {
+            map = new Dictionary<string, EnabledNodeTypeRestrictions>();
+
+
+            Type type = new EnabledNodeTypeRestrictions().GetType();
+            var values = System.Enum.GetValues(type);
+
+            foreach (int val in values)
+            {
+                EnabledNodeTypeRestrictions item = (EnabledNodeTypeRestrictions)val;
+
+                var memberInfo = type.GetMember(type.GetEnumName(val));
+                var descriptionAttribute = memberInfo[0]
+                    .GetCustomAttributes(typeof(DescriptionAttribute), false)
+                    .FirstOrDefault() as DescriptionAttribute;
+
+                map.Add(descriptionAttribute.Description, item);
+            }
+        }
+
+
+        /// <summary>
+        /// The marks to validate against.
+        /// </summary>
+        public List<EnabledNodeTypeRestrictions> EnabledNodeTypes { get; set; }
+
+        /// <summary>
+        /// The custom error message that should be displayed.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="EnabledNodeTypesValidator"/>.
+        /// </summary>
+        /// <param name="enabledNodeTypes">The node types to validate against.</param>
+        /// <param name="message">The custom error message for this validation.</param>
+        public EnabledNodeTypesValidator(IEnumerable<EnabledNodeTypeRestrictions> enabledNodeTypes, string message = null)
+        {
+            EnabledNodeTypes = enabledNodeTypes?.ToList();
+            Message = message;
+        }
+
+
+        public static string fromEnum(EnabledNodeTypeRestrictions item)
+        {
+            return map.FirstOrDefault(x => x.Value == item).Key;
+        }
+
+        public static EnabledNodeTypeRestrictions toEnum(string item)
+        {
+                return map[item];       
+        }
+
+        /// <summary>
+        /// Creates a representation of this validator that can be easily serialized.
+        /// </summary>
+        /// <returns>The object to serialize.</returns>
+        public object CreateValidator()
+        {
+            return new { enabledNodeTypes = EnabledNodeTypes.Select(c => fromEnum(c)?.ToLower()), message = Message };
+        }
+    }
+
+
+
+    /// <summary>
+    /// Represents a validator that validates the EnabledMarks property.
+    /// </summary>
+    /// <summary>
+    /// Represents a validator that validates the Enabled marks />
+    /// </summary>
+    public class EnabledMarksValidator : IFieldValidator
+    {
+        /// <summary>
+        /// The marks to validate against.
+        /// </summary>
+        public List<EnabledMarkRestrictions> EnabledMarks { get; set; }
+
+        /// <summary>
+        /// The custom error message that should be displayed.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="EnabledMarksValidator"/>.
+        /// </summary>
+        /// <param name="enabledMarks">The marks to validate against.</param>
+        /// <param name="message">The custom error message for this validation.</param>
+        public EnabledMarksValidator(IEnumerable<EnabledMarkRestrictions> enabledMarks, string message = null)
+        {
+            EnabledMarks = enabledMarks?.ToList();
+            Message = message;
+        }
+
+        /// <summary>
+        /// Creates a representation of this validator that can be easily serialized.
+        /// </summary>
+        /// <returns>The object to serialize.</returns>
+        public object CreateValidator()
+        {
+            return new { enabledMarks = EnabledMarks.Select(c => c.ToString()?.ToLower()), message = Message };
+        }
     }
 
     /// <summary>
@@ -307,43 +472,43 @@ namespace Contentful.Core.Models.Management
     /// Represents a validator that ensures that the field value is within a certain date range.
     /// </summary>  
     public class DateRangeValidator : IFieldValidator
-	{
-		private string _min;
+    {
+        private string _min;
 
-		/// <summary>
-		/// The minimum allowed date.
-		/// </summary>
-		public DateTime? Min
-		{
-			get
-			{
+        /// <summary>
+        /// The minimum allowed date.
+        /// </summary>
+        public DateTime? Min
+        {
+            get
+            {
                 if (DateTime.TryParse(_min, out DateTime parsed))
                     return (DateTime?)parsed;
 
                 return null;
-			}
-		}
+            }
+        }
 
-		private string _max;
+        private string _max;
 
-		/// <summary>
-		/// The maximum allowed date.
-		/// </summary>
-		public DateTime? Max
-		{
-			get
-			{
+        /// <summary>
+        /// The maximum allowed date.
+        /// </summary>
+        public DateTime? Max
+        {
+            get
+            {
                 if (DateTime.TryParse(_max, out DateTime parsed))
                     return (DateTime?)parsed;
 
                 return null;
-			}
-		}
+            }
+        }
 
-		/// <summary>
-		/// The custom error message that should be displayed.
-		/// </summary>
-		public string Message { get; set; }
+        /// <summary>
+        /// The custom error message that should be displayed.
+        /// </summary>
+        public string Message { get; set; }
 
 
         /// <summary>
@@ -353,137 +518,137 @@ namespace Contentful.Core.Models.Management
         /// <param name="max">The maximum date of the range.</param>
         /// <param name="message">The custom error message for this validation.</param>
         public DateRangeValidator(string min, string max, string message = null)
-		{
-			_min = min;
-			_max = max;
+        {
+            _min = min;
+            _max = max;
             Message = message;
-		}
+        }
 
         /// <summary>
         /// Creates a representation of this validator that can be easily serialized.
         /// </summary>
         /// <returns>The object to serialize.</returns>
 		public object CreateValidator()
-		{
-			return new { dateRange = new { min = _min, max = _max }, message = Message };
-		}
-	}
+        {
+            return new { dateRange = new { min = _min, max = _max }, message = Message };
+        }
+    }
 
     /// <summary>
     /// Represents a validator that ensures that the media file size is within a certain size range.
     /// </summary>      
     public class FileSizeValidator : IFieldValidator
-	{
-		private const int BYTES_IN_KB = 1024;
-		private const int BYTES_IN_MB = 1048576;
-		/// <summary>
-		/// The minimum allowed size of the file.
-		/// </summary>
-		public int? Min { get; set; }
+    {
+        private const int BYTES_IN_KB = 1024;
+        private const int BYTES_IN_MB = 1048576;
+        /// <summary>
+        /// The minimum allowed size of the file.
+        /// </summary>
+        public int? Min { get; set; }
 
-		/// <summary>
-		/// The maximum allowed size of the file.
-		/// </summary>
-		public int? Max { get; set; }
-		/// <summary>
-		/// The custom error message that should be displayed.
-		/// </summary>
-		public string Message { get; set; }
+        /// <summary>
+        /// The maximum allowed size of the file.
+        /// </summary>
+        public int? Max { get; set; }
+        /// <summary>
+        /// The custom error message that should be displayed.
+        /// </summary>
+        public string Message { get; set; }
 
-		/// <summary>
-		/// Initializes a new instance of <see cref="FileSizeValidator" />.
-		/// </summary>
-		/// <param name="min">The minimum size of the file.</param>
-		/// <param name="max">The maximum size of the file.</param>
-		/// <param name="minUnit">The unit measuring the minimum file size.</param>
-		/// <param name="maxUnit">The unit measuring the maximum file size.</param>
-		/// <param name="message">The custom error message for this validation.</param>
-		public FileSizeValidator(int? min, int? max, string minUnit = SystemFileSizeUnits.Bytes, string maxUnit = SystemFileSizeUnits.Bytes, string message = null)
-		{
+        /// <summary>
+        /// Initializes a new instance of <see cref="FileSizeValidator" />.
+        /// </summary>
+        /// <param name="min">The minimum size of the file.</param>
+        /// <param name="max">The maximum size of the file.</param>
+        /// <param name="minUnit">The unit measuring the minimum file size.</param>
+        /// <param name="maxUnit">The unit measuring the maximum file size.</param>
+        /// <param name="message">The custom error message for this validation.</param>
+        public FileSizeValidator(int? min, int? max, string minUnit = SystemFileSizeUnits.Bytes, string maxUnit = SystemFileSizeUnits.Bytes, string message = null)
+        {
             Min = GetCalculatedByteSize(min, minUnit);
             Max = GetCalculatedByteSize(max, maxUnit);
             Message = message;
-		}
+        }
 
         /// <summary>
         /// Creates a representation of this validator that can be easily serialized.
         /// </summary>
         /// <returns>The object to serialize.</returns>
 		public object CreateValidator()
-		{
-			return new { assetFileSize = new { min = Min, max = Max }, message = Message };
-		}
+        {
+            return new { assetFileSize = new { min = Min, max = Max }, message = Message };
+        }
 
 
-		private int? GetCalculatedByteSize(int? value, string unit)
-		{
-			if (value != null)
-			{
-				if (unit == SystemFileSizeUnits.KB)
-					value = value * BYTES_IN_KB;
-				if (unit == SystemFileSizeUnits.MB)
-					value = value * BYTES_IN_MB;
-			}
-			return value;
-		}
-	}
-    
+        private int? GetCalculatedByteSize(int? value, string unit)
+        {
+            if (value != null)
+            {
+                if (unit == SystemFileSizeUnits.KB)
+                    value = value * BYTES_IN_KB;
+                if (unit == SystemFileSizeUnits.MB)
+                    value = value * BYTES_IN_MB;
+            }
+            return value;
+        }
+    }
+
     /// <summary>
     /// Represents a validator that ensures that the image dimensions are within a certain range.
     /// </summary>   
     public class ImageSizeValidator : IFieldValidator
-	{
-		/// <summary>
-		/// The minimum allowed width of the image (in px).
-		/// </summary>
-		public int? MinWidth { get; set; }
+    {
+        /// <summary>
+        /// The minimum allowed width of the image (in px).
+        /// </summary>
+        public int? MinWidth { get; set; }
 
-		/// <summary>
-		/// The maximum allowed width of the image (in px).
-		/// </summary>
-		public int? MaxWidth { get; set; }
-		/// <summary>
-		/// The minimum allowed height of the iamge (in px).
-		/// </summary>
-		int? MinHeight { get; set; }
+        /// <summary>
+        /// The maximum allowed width of the image (in px).
+        /// </summary>
+        public int? MaxWidth { get; set; }
+        /// <summary>
+        /// The minimum allowed height of the iamge (in px).
+        /// </summary>
+        int? MinHeight { get; set; }
 
-		/// <summary>
-		/// The maximum allowed height of the image (in px).
-		/// </summary>
-		public int? MaxHeight { get; set; }
+        /// <summary>
+        /// The maximum allowed height of the image (in px).
+        /// </summary>
+        public int? MaxHeight { get; set; }
 
-		/// <summary>
-		/// The custom error message that should be displayed.
-		/// </summary>
-		public string Message { get; set; }
+        /// <summary>
+        /// The custom error message that should be displayed.
+        /// </summary>
+        public string Message { get; set; }
 
 
-		/// <summary>
-		/// Initializes a new instance of <see cref="ImageSizeValidator" />.
-		/// </summary>
-		/// <param name="minWidth">The minimum width of the image.</param>
-		/// <param name="maxWidth">The maximum width of the image.</param>
-		/// <param name="minHeight">The minimum height of the image.</param>
-		/// <param name="maxHeight">The maximum height of the image.</param>
-		/// <param name="message">The custom error message for this validation.</param>
-		public ImageSizeValidator(int? minWidth, int? maxWidth, int? minHeight, int? maxHeight, string message = null)
-		{
+        /// <summary>
+        /// Initializes a new instance of <see cref="ImageSizeValidator" />.
+        /// </summary>
+        /// <param name="minWidth">The minimum width of the image.</param>
+        /// <param name="maxWidth">The maximum width of the image.</param>
+        /// <param name="minHeight">The minimum height of the image.</param>
+        /// <param name="maxHeight">The maximum height of the image.</param>
+        /// <param name="message">The custom error message for this validation.</param>
+        public ImageSizeValidator(int? minWidth, int? maxWidth, int? minHeight, int? maxHeight, string message = null)
+        {
             MinWidth = minWidth;
             MaxWidth = maxWidth;
             MinHeight = minHeight;
             MaxHeight = maxHeight;
             Message = message;
-		}
+        }
 
         /// <summary>
         /// Creates a representation of this validator that can be easily serialized.
         /// </summary>
         /// <returns>The object to serialize.</returns>
 		public object CreateValidator()
-		{
-			return new { assetImageDimensions = new { width = new { min = MinWidth, max = MaxWidth }, height = new { min = MinHeight, max = MaxHeight } }, message = Message };
-		}
-	}
+        {
+            return new { assetImageDimensions = new { width = new { min = MinWidth, max = MaxWidth }, height = new { min = MinHeight, max = MaxHeight } }, message = Message };
+        }
+    }
 
     /// <summary>
     /// Represents a validator that validates the nodes of a rich text field.


### PR DESCRIPTION
Hi there.

The production API was breaking on GetContentTypes.  After some investigation it turned out that the deserialization from JSON to the ContentType wasn't working for rich text validations because it wasn't set up in the API.

I added the two additional validations needed and updated associated unit tests and content to make GetContentTypes work.  I didn't investigate pushing content types up so this may be a scenario that needs further investigation.

Thanks