### PR TITLE
Fix SrcDoc serialization for UI extension

### DIFF
--- a/Contentful.Core/Models/Management/UiExtension.cs
+++ b/Contentful.Core/Models/Management/UiExtension.cs
@@ -26,7 +26,7 @@ namespace Contentful.Core.Models.Management
         /// <summary>
         /// String representation of the widget, e.g. inline HTML.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("srcdoc", NullValueHandling = NullValueHandling.Ignore)]
         public string SrcDoc { get; set; }
 
         /// <summary>


### PR DESCRIPTION
CreateExtension request fails is SrcDoc provided:
```
contentfulManagementClient.CreateExtension(new UiExtension{
                FieldTypes = new List<string>(),
                Name = "The Extension",
                SrcDoc = "test",
                Sidebar = true
});
```
Post request payload:
```
{
  "extension": {
    "srcDoc": "test",
    "name": "The Extension",
    "fieldTypes": [],
    "sidebar": true
  }
}
```
Error: 
```
Contentful.Core.Errors.ContentfulException: Validation error[
  {
    "name": "unexpected",
    "details": "The property \"srcDoc\" is not expected",
    "path": [
      "extension",
      "srcDoc"
    ]
  },
  {
    "name": "required",
    "details": "The property \"src\" is required here",
    "path": [
      "extension",
      "src"
    ]
  },
  {
    "name": "required",
    "details": "The property \"srcdoc\" is required here",
    "path": [
      "extension",
      "srcdoc"
    ]
  },
  {
    "name": "unless",
    "details": "The property \"src\" or \"srcdoc\" are required here",
    "path": [
      "extension"
    ]
  }
]
```