### PR TITLE
Exposing Renderers so they can be used in Custom Renderers

### DIFF
--- a/Contentful.Core/Models/Authoring.cs
+++ b/Contentful.Core/Models/Authoring.cs
@@ -30,6 +30,11 @@ namespace Contentful.Core.Models
     {
         private readonly ContentRendererCollection _contentRendererCollection;
 
+        public ContentRendererCollection Renderers
+        {
+            get { return _contentRendererCollection; }
+        }
+
         /// <summary>
         /// Initializes a new instance of HtmlRenderer.
         /// </summary>


### PR DESCRIPTION
I need to be able to get hold of the Renderer Collection for use in a custom link renderer, so this will expose it and allow it to be used