### PR TITLE
Change version param to optional

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -102,7 +102,7 @@ namespace Contentful.Core
         /// <param name="organisation">The organisation to update a space for. Not required if the account belongs to only one organisation.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Space"/></returns>
-        public async Task<Space> UpdateSpaceName(string id, string name, int version, string organisation = null, CancellationToken cancellationToken = default)
+        public async Task<Space> UpdateSpaceName(string id, string name, int? version = default, string organisation = null, CancellationToken cancellationToken = default)
         {
             var res = await PutAsync($"{_baseUrl}{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version, organisationId: organisation).ConfigureAwait(false);
 
@@ -197,7 +197,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created or updated <see cref="ContentType"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if the id of the content type is not set.</exception>
-        public async Task<ContentType> CreateOrUpdateContentType(ContentType contentType, string spaceId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<ContentType> CreateOrUpdateContentType(ContentType contentType, string spaceId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             if (contentType.SystemProperties?.Id == null)
             {
@@ -273,7 +273,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into a <see cref="ContentType"/>.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="contentTypeId">contentTypeId</see> parameter was null or empty</exception>
-        public async Task<ContentType> ActivateContentType(string contentTypeId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ContentType> ActivateContentType(string contentTypeId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(contentTypeId))
             {
@@ -377,7 +377,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into a <see cref="Contentful.Core.Models.Management.EditorInterface"/>.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="contentTypeId">contentTypeId</see> parameter was null or empty</exception>
-        public async Task<EditorInterface> UpdateEditorInterface(EditorInterface editorInterface, string contentTypeId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<EditorInterface> UpdateEditorInterface(EditorInterface editorInterface, string contentTypeId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(contentTypeId))
             {
@@ -557,7 +557,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the entry. Must be set when updating an entry.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created or updated <see cref="Entry{T}"/>.</returns>
-        public async Task<Entry<dynamic>> CreateOrUpdateEntry(Entry<dynamic> entry, string spaceId = null, string contentTypeId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<Entry<dynamic>> CreateOrUpdateEntry(Entry<dynamic> entry, string spaceId = null, string contentTypeId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entry.SystemProperties?.Id))
             {
@@ -585,7 +585,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the entry. Must be set when updating an entry.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created or updated entry.</returns>
-        public async Task<T> CreateOrUpdateEntry<T>(T entry, string id, string spaceId = null, string contentTypeId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<T> CreateOrUpdateEntry<T>(T entry, string id, string spaceId = null, string contentTypeId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             var entryToCreate = new Entry<dynamic>
             {
@@ -711,7 +711,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="entryId">entryId</see> parameter was null or empty.</exception>
-        public async Task DeleteEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task DeleteEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entryId))
             {
@@ -733,7 +733,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="entryId">entryId</see> parameter was null or empty.</exception>
-        public async Task<Entry<dynamic>> PublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<Entry<dynamic>> PublishEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entryId))
             {
@@ -757,7 +757,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="entryId">entryId</see> parameter was null or empty.</exception>
-        public async Task<Entry<dynamic>> UnpublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<Entry<dynamic>> UnpublishEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entryId))
             {
@@ -781,7 +781,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="entryId">entryId</see> parameter was null or empty.</exception>
-        public async Task<Entry<dynamic>> ArchiveEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<Entry<dynamic>> ArchiveEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entryId))
             {
@@ -805,7 +805,7 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="entryId">entryId</see> parameter was null or empty.</exception>
-        public async Task<Entry<dynamic>> UnarchiveEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<Entry<dynamic>> UnarchiveEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(entryId))
             {
@@ -909,7 +909,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or empty.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task DeleteAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task DeleteAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(assetId))
             {
@@ -931,7 +931,7 @@ namespace Contentful.Core
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> published.</returns>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or empty.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ManagementAsset> PublishAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ManagementAsset> PublishAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(assetId))
             {
@@ -957,7 +957,7 @@ namespace Contentful.Core
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> unpublished.</returns>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or empty.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ManagementAsset> UnpublishAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ManagementAsset> UnpublishAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(assetId))
             {
@@ -983,7 +983,7 @@ namespace Contentful.Core
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> archived.</returns>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or empty.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ManagementAsset> ArchiveAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ManagementAsset> ArchiveAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(assetId))
             {
@@ -1011,7 +1011,7 @@ namespace Contentful.Core
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> unarchived.</returns>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or empty.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ManagementAsset> UnarchiveAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ManagementAsset> UnarchiveAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(assetId))
             {
@@ -1100,7 +1100,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Contentful.Core.Models.Management.ManagementAsset"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ManagementAsset> CreateOrUpdateAsset(ManagementAsset asset, string spaceId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<ManagementAsset> CreateOrUpdateAsset(ManagementAsset asset, string spaceId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(asset.SystemProperties?.Id))
             {
@@ -1320,7 +1320,7 @@ namespace Contentful.Core
         /// <returns>The created <see cref="Contentful.Core.Models.Management.Webhook"/>.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The id of the webhook parameter was null or empty.</exception>
-        public async Task<Webhook> CreateOrUpdateWebhook(Webhook webhook, string spaceId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<Webhook> CreateOrUpdateWebhook(Webhook webhook, string spaceId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(webhook?.SystemProperties?.Id))
             {
@@ -1930,7 +1930,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Contentful.Core.Models.Management.ApiKey"/>.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ApiKey> UpdateApiKey(string id, string name, string description, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ApiKey> UpdateApiKey(string id, string name, string description, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -2167,7 +2167,7 @@ namespace Contentful.Core
         /// <returns>The created or updated <see cref="Contentful.Core.Models.Management.UiExtension"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if the id of the content type is not set.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<UiExtension> CreateOrUpdateExtension(UiExtension extension, string spaceId = null, int? version = null, CancellationToken cancellationToken = default)
+        public async Task<UiExtension> CreateOrUpdateExtension(UiExtension extension, string spaceId = null, int? version = default, CancellationToken cancellationToken = default)
         {
             if (extension.SystemProperties?.Id == null)
             {
@@ -2403,7 +2403,7 @@ namespace Contentful.Core
         /// <returns>The created <see cref="Contentful.Core.Models.Management.ContentfulEnvironment"/>.</returns>
         /// <exception cref="ArgumentException">The required arguments were not provided.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulEnvironment> CreateOrUpdateEnvironment(string id, string name, int? version = null, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ContentfulEnvironment> CreateOrUpdateEnvironment(string id, string name, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -2766,7 +2766,7 @@ namespace Contentful.Core
         /// <returns>The created or updated <see cref="Contentful.Core.Models.Management.ContentTag"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if the id or the name is not set.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentTag> UpdateContentTag(string name, string id, int version, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ContentTag> UpdateContentTag(string name, string id, int? version = default, string spaceId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -2820,12 +2820,12 @@ namespace Contentful.Core
             return await SendHttpRequest(url, HttpMethod.Put, _options.ManagementApiKey, cancellationToken, content, version, contentTypeId, organisationId, additionalHeaders: additionalHeaders).ConfigureAwait(false);
         }
 
-        private async Task<HttpResponseMessage> DeleteAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private async Task<HttpResponseMessage> DeleteAsync(string url, CancellationToken cancellationToken, int? version = default, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
             return await SendHttpRequest(url, HttpMethod.Delete, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
         }
 
-        private async Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private async Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken, int? version = default, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
             return await SendHttpRequest(url, HttpMethod.Get, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
         }

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -650,7 +650,7 @@ namespace Contentful.Core
         public async Task<Entry<dynamic>> UpdateEntryForLocale(object entry, string id, string locale = null, string spaceId = null, CancellationToken cancellationToken = default)
         {
             var entryToUpdate = await GetEntry(id, spaceId);
-            var contentType = await GetContentType(entryToUpdate.SystemProperties.ContentType.SystemProperties.Id);
+            var contentType = await GetContentType(entryToUpdate.SystemProperties.ContentType.SystemProperties.Id, spaceId);
             var allFieldIds = contentType.Fields.Select(f => f.Id);
 
             if (string.IsNullOrEmpty(locale))

--- a/Contentful.Core/IContentfulManagementClient.cs
+++ b/Contentful.Core/IContentfulManagementClient.cs
@@ -20,7 +20,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space to activate the content type in. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into a <see cref="ContentType"/>.</returns>
-        Task<ContentType> ActivateContentType(string contentTypeId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ContentType> ActivateContentType(string contentTypeId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Archives an asset by the specified id.
@@ -30,7 +30,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> archived.</returns>
-        Task<ManagementAsset> ArchiveAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ManagementAsset> ArchiveAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Archives an entry by the specified id.
@@ -40,7 +40,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
-        Task<Entry<dynamic>> ArchiveEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<Entry<dynamic>> ArchiveEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates an <see cref="Contentful.Core.Models.Management.ApiKey"/> in a space.
@@ -63,7 +63,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Contentful.Core.Models.Management.ApiKey"/>.</returns>
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        Task<ApiKey> UpdateApiKey(string id, string name, string description, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ApiKey> UpdateApiKey(string id, string name, string description, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a locale in the specified <see cref="Space"/>.
@@ -145,7 +145,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the entry. Must be set when updating an entry.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created or updated entry.</returns>
-        Task<T> CreateOrUpdateEntry<T>(T entry, string id, string spaceId = null, string contentTypeId = null, int? version = null, CancellationToken cancellationToken = default);
+        Task<T> CreateOrUpdateEntry<T>(T entry, string id, string spaceId = null, string contentTypeId = null, int? version = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates an entry with values for a certain locale from the provided object.
@@ -179,7 +179,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the webhook.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created <see cref="Contentful.Core.Models.Management.Webhook"/>.</returns>
-        Task<Webhook> CreateOrUpdateWebhook(Webhook webhook, string spaceId = null, int? version = null, CancellationToken cancellationToken = default);
+        Task<Webhook> CreateOrUpdateWebhook(Webhook webhook, string spaceId = null, int? version = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a role in a <see cref="Space"/>.
@@ -234,7 +234,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the asset.</param>
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
-        Task DeleteAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task DeleteAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a <see cref="ContentType"/> by the specified id.
@@ -252,7 +252,7 @@ namespace Contentful.Core
         /// <param name="version">The last known version of the entry.</param>
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
-        Task DeleteEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task DeleteEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a locale by the specified id.
@@ -653,7 +653,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> published.</returns>
-        Task<ManagementAsset> PublishAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ManagementAsset> PublishAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Publishes an entry by the specified id.
@@ -663,7 +663,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
-        Task<Entry<dynamic>> PublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<Entry<dynamic>> PublishEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unarchives an asset by the specified id.
@@ -673,7 +673,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> unarchived.</returns>
-        Task<ManagementAsset> UnarchiveAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ManagementAsset> UnarchiveAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unarchives an entry by the specified id.
@@ -683,7 +683,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
-        Task<Entry<dynamic>> UnarchiveEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<Entry<dynamic>> UnarchiveEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unpublishes an asset by the specified id.
@@ -693,7 +693,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The <see cref="Contentful.Core.Models.Management.ManagementAsset"/> unpublished.</returns>
-        Task<ManagementAsset> UnpublishAsset(string assetId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ManagementAsset> UnpublishAsset(string assetId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unpublishes an entry by the specified id.
@@ -703,7 +703,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
-        Task<Entry<dynamic>> UnpublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<Entry<dynamic>> UnpublishEntry(string entryId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a <see cref="Contentful.Core.Models.Management.EditorInterface"/> for a specific <see cref="ContentType"/>.
@@ -714,7 +714,7 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into a <see cref="Contentful.Core.Models.Management.EditorInterface"/>.</returns>
-        Task<EditorInterface> UpdateEditorInterface(EditorInterface editorInterface, string contentTypeId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<EditorInterface> UpdateEditorInterface(EditorInterface editorInterface, string contentTypeId, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a locale in the specified <see cref="Space"/>.
@@ -761,7 +761,7 @@ namespace Contentful.Core
         /// <param name="organisation">The organisation to update a space for. Not required if the account belongs to only one organisation.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Space"/></returns>
-        Task<Space> UpdateSpaceName(string id, string name, int version, string organisation = null, CancellationToken cancellationToken = default);
+        Task<Space> UpdateSpaceName(string id, string name, int? version = default, string organisation = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets an upload <see cref="SystemProperties"/> by the specified id.
@@ -825,7 +825,7 @@ namespace Contentful.Core
         /// <param name="version">The last version known of the extension. Must be set for existing extensions. Should be null if one is created.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The created or updated <see cref="Contentful.Core.Models.Management.UiExtension"/>.</returns>
-        Task<UiExtension> CreateOrUpdateExtension(UiExtension extension, string spaceId = null, int? version = null, CancellationToken cancellationToken = default);
+        Task<UiExtension> CreateOrUpdateExtension(UiExtension extension, string spaceId = null, int? version = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a single <see cref="Contentful.Core.Models.Management.UiExtension"/> for a space.
@@ -922,7 +922,7 @@ namespace Contentful.Core
         /// <returns>The created <see cref="Contentful.Core.Models.Management.ContentfulEnvironment"/>.</returns>
         /// <exception cref="System.ArgumentException">The required arguments were not provided.</exception>
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        Task<ContentfulEnvironment> CreateOrUpdateEnvironment(string id, string name, int? version = null, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ContentfulEnvironment> CreateOrUpdateEnvironment(string id, string name, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Clones a <see cref="Contentful.Core.Models.Management.ContentfulEnvironment"/> for a space.
@@ -1097,7 +1097,7 @@ namespace Contentful.Core
         /// <returns>The created or updated <see cref="Contentful.Core.Models.Management.ContentTag"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if the id or the name is not set.</exception>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        Task<ContentTag> UpdateContentTag(string name, string id, int version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ContentTag> UpdateContentTag(string name, string id, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
 
 
         /// <summary>
@@ -1109,6 +1109,6 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="contentTypeId">contentTypeId</see> parameter was null or empty</exception>
-        Task DeleteContentTag(string id, int? version, string spaceId = null, CancellationToken cancellationToken = default);
+        Task DeleteContentTag(string id, int? version = default, string spaceId = null, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Proposal: make the version param optional so that we can update the last version of the item and removing the need to query the item beforehand (if version is not relevant)