### PR TITLE
Fix GetAssetsCollection by passing spaceId to CreateOrUpdateAsset

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -827,7 +827,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of <see cref="Contentful.Core.Models.Management.ManagementAsset"/>.</returns>
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<Asset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
+        public async Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<ManagementAsset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
         {
             return await GetAssetsCollection(queryBuilder?.Build(), spaceId, cancellationToken).ConfigureAwait(false);
         }
@@ -2102,12 +2102,12 @@ namespace Contentful.Core
                 file.Value.UploadReference = upload;
             }
 
-            var createdAsset = await CreateOrUpdateAsset(asset);
+            var createdAsset = await CreateOrUpdateAsset(asset, spaceId);
 
             foreach (var file in createdAsset.Files)
             {
 
-                await ProcessAsset(createdAsset.SystemProperties.Id, createdAsset.SystemProperties.Version ?? 1, file.Key);
+                await ProcessAsset(createdAsset.SystemProperties.Id, createdAsset.SystemProperties.Version ?? 1, file.Key, spaceId);
             }
 
             return createdAsset;

--- a/Contentful.Core/IContentfulManagementClient.cs
+++ b/Contentful.Core/IContentfulManagementClient.cs
@@ -391,7 +391,7 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of <see cref="Contentful.Core.Models.Management.ManagementAsset"/>.</returns>
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<Asset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default);
+        Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<ManagementAsset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default);
 
 
         /// <summary>


### PR DESCRIPTION
Particularly [these](https://github.com/contentful/contentful.net/pull/250/files#diff-1584378cf2f8101a0c15a8db1c4034e8d9d3e983c7e95407c8498b7bd508989bR2105) changes fix a bug. 

The change to `ManagementAsset` can be reverted