### PR TITLE
Issue #261 consistency of Entry<T> when fetching single entry by id.

### DIFF
--- a/Contentful.Core.Tests/ContentfulClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulClientTests.cs
@@ -104,6 +104,22 @@ namespace Contentful.Core.Tests
         }
 
         [Fact]
+        public async Task GetEntryShouldSerializeResponseToEntryCorrectly()
+        {
+            //Arrange
+            _handler.Response = GetResponseFromFile(@"SampleEntry.json");
+            
+            //Act
+            var res = await _client.GetEntry<Entry<TestEntryModel>>("12");
+
+            //Assert
+            Assert.Equal("SoSo Wall Clock", res.Fields.ProductName);
+            Assert.Equal("soso-wall-clock", res.Fields.Slug);
+            Assert.Contains("bleh", res.Fields.Metadata);
+            Assert.Equal("bob", res.Metadata.Tags[0].Sys.Id);
+        }
+        
+        [Fact]
         public async Task GetEntryShouldSerializeResponseToArbitraryModelWithSystemPropertiesCorrectly()
         {
             //Arrange


### PR DESCRIPTION
This commit address issue [#261](https://github.com/contentful/contentful.net/issues/261) to update
`GetEntry<T>` with documentation and `GetEntries<T>`.

In order to do this, a check on the generic parameter to only flatten when T is not Entry<U> has been added.  Otherwise, the implementation goes back to the existing one to push back the fields to the same level as system and metadata properties.

All tests pass and an additional test demonstrating update behavior has been added.