### PR TITLE
 New method for creating embargoed asset keys using delivery/preview API

### DIFF
--- a/Contentful.Core.Tests/Contentful.Core.Tests.csproj
+++ b/Contentful.Core.Tests/Contentful.Core.Tests.csproj
@@ -28,6 +28,7 @@
     <EmbeddedResource Include="JsonFiles\EnvironmentsCollection.json" />
     <EmbeddedResource Include="JsonFiles\EntriesCollectionWithSelfreference.json" />
     <EmbeddedResource Include="JsonFiles\EntriesMultipleLocale.json" />
+    <EmbeddedResource Include="JsonFiles\EmbargoAssetKey.json" />
     <EmbeddedResource Include="JsonFiles\NestedSharedStructure.json" />
     <EmbeddedResource Include="JsonFiles\EntriesCollectionWithoutSys.json" />
     <EmbeddedResource Include="JsonFiles\EntriesCollectionWithIncludesMissingEntries.json" />

--- a/Contentful.Core.Tests/ContentfulClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulClientTests.cs
@@ -1244,6 +1244,35 @@ namespace Contentful.Core.Tests
             Assert.Contains("<p><strong>Bold Text</strong></p><p><em>Italic Text</em></p><p><u>Underline Text</u></p>", html);
         }
 
+        [Fact]
+        public void CreateEmbargoedAssetThrowsWhenPastDateIsUsed()
+        {
+            // Arrange
+            var client = GetClientWithEnvironment();
+            var past = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            
+            // Act
+
+            // Assert
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.CreateEmargoedAssetKey(past));
+        }
+
+        [Fact]
+        public async Task CreateEmbargoedAssetKeyShouldReturnCorrectKey()
+        {
+            //Arrange
+            _handler.Response = GetResponseFromFile(@"EmbargoAssetKey.json");
+            var expiry = DateTimeOffset.UtcNow.AddHours(10);
+            
+            //Act
+            var res = await _client.CreateEmargoedAssetKey(expiry);
+
+            //Assert
+            Assert.Equal(expiry.DateTime,res.ExpiresAtUtc);
+            Assert.Equal("c2VjcmV0",res.Secret);
+            Assert.Equal("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE6MSJ9.eyJleHAiOjE2Mzc2MjM4MDAsInN1YiI6InRlc3RzcGFjZXZhbHVlIiwiYXVkIjoiYWRuIiwianRpIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwiY3RmOnVucHViIjp0cnVlfQ.BHtBHdrInzu3KtGxTJ7FLxGF0WN9HEdJ9C5CeB3hx7g", res.Policy);
+        }
+
         private ContentfulClient GetClientWithEnvironment(string env = "special")
         {
             var httpClient = new HttpClient(_handler);

--- a/Contentful.Core.Tests/Extensions/JsonConversionExtensionsTests.cs
+++ b/Contentful.Core.Tests/Extensions/JsonConversionExtensionsTests.cs
@@ -1,0 +1,154 @@
+using Contentful.Core.Extensions;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Contentful.Core.Tests.Extensions
+{
+    public class JsonConversionExtensionsTests
+    {
+        [Fact]
+        public void JsonConversionExtensionsWorksSimpleObject()
+        {
+            // Arrange
+            var obj = new
+            {
+                foo = "bar"
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"foo\":\"bar\"}", convertedString);
+        }
+
+        [Fact]
+        public void JsonConversionExtensionsWorksNestedObject()
+        {
+            // Arrange
+            var obj = new
+            {
+                foo = "bar",
+                bar = new
+                {
+                    baz = "qux"
+                }
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"foo\":\"bar\",\"bar\":{\"baz\":\"qux\"}}", convertedString);
+        }
+
+        [Fact]
+        public void JsonConversionExtensionsWorksArray()
+        {
+            // Arrange
+            var obj = new
+            {
+                foo = "bar",
+                bar = new
+                {
+                    baz = "qux"
+                },
+                baz = new[] {
+              new {
+                foo = "bar"
+              },
+              new {
+                foo = "baz"
+              }
+            }
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"foo\":\"bar\",\"bar\":{\"baz\":\"qux\"},\"baz\":[{\"foo\":\"bar\"},{\"foo\":\"baz\"}]}", convertedString);
+        }
+
+        [Fact]
+        public void JsonConversionExtensionsWorksArrayWithNull()
+        {
+            // Arrange
+            var obj = new
+            {
+                foo = "bar",
+                bar = new
+                {
+                    baz = "qux"
+                },
+                baz = new[] {
+              new {
+                foo = "bar"
+              },
+              null
+            }
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"foo\":\"bar\",\"bar\":{\"baz\":\"qux\"},\"baz\":[{\"foo\":\"bar\"},null]}", convertedString);
+        }
+
+        [Fact]
+        public void JsonConversionExtensionsConvertsToCamlCase()
+        {
+            // Arrange
+            var obj = new
+            {
+                ThisIsATest = "bar",
+                ThisIsAnotherTest = "baz",
+                this_is_a_test_snake = "qux"
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"thisIsATest\":\"bar\",\"thisIsAnotherTest\":\"baz\",\"this_is_a_test_snake\":\"qux\"}", convertedString);
+        }
+
+        [Fact]
+        public void JsonConversionExtensionsConvertsEmargoedAssetBodyCorrectly()
+        {
+            // Arrange
+            var obj = new
+            {
+                ExpiresAt = new DateTimeOffset(2021, 5, 12, 3, 4, 5, TimeSpan.Zero).ToUnixTimeMilliseconds()
+            };
+
+            // Act
+            var convertedString = obj.ConvertObjectToJsonString();
+
+            // Assert
+            Assert.Equal("{\"expiresAt\":1620788645000}", convertedString);
+
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(13, 13)]
+        [InlineData(896, 896)]
+        [InlineData(-345, -345)]
+        public void ParsingNullableIntValuesShouldYieldCorrectResult(int? val, int? exptected)
+        {
+            //Arrange
+            var token = new JObject(new JProperty("val", val))["val"];
+
+            //Act
+            var res = token.ToNullableInt();
+
+            //Assert
+            Assert.Equal(exptected, res);
+        }
+    }
+}

--- a/Contentful.Core.Tests/JsonFiles/EmbargoAssetKey.json
+++ b/Contentful.Core.Tests/JsonFiles/EmbargoAssetKey.json
@@ -1,0 +1,5 @@
+{
+    "policy": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE6MSJ9.eyJleHAiOjE2Mzc2MjM4MDAsInN1YiI6InRlc3RzcGFjZXZhbHVlIiwiYXVkIjoiYWRuIiwianRpIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwiY3RmOnVucHViIjp0cnVlfQ.BHtBHdrInzu3KtGxTJ7FLxGF0WN9HEdJ9C5CeB3hx7g",
+    "secret": "c2VjcmV0"
+  }
+  

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -1,5 +1,6 @@
 ﻿using Contentful.Core.Configuration;
 using Contentful.Core.Errors;
+using Contentful.Core.Extensions;
 using Contentful.Core.Models;
 using Contentful.Core.Models.Management;
 using Contentful.Core.Search;
@@ -617,7 +618,7 @@ namespace Contentful.Core
                 locale = (await GetLocalesCollection(spaceId, cancellationToken)).FirstOrDefault(c => c.Default).Code;
             }
 
-            var jsonEntry = JObject.Parse(ConvertObjectToJsonString(entry));
+            var jsonEntry = JObject.Parse(entry.ConvertObjectToJsonString());
             var jsonToCreate = new JObject();
             foreach (var prop in jsonEntry.Children().Where(p => p is JProperty).Cast<JProperty>())
             {
@@ -658,7 +659,7 @@ namespace Contentful.Core
                 locale = (await GetLocalesCollection(spaceId, cancellationToken)).FirstOrDefault(c => c.Default).Code;
             }
 
-            var jsonEntry = JObject.Parse(ConvertObjectToJsonString(entry));
+            var jsonEntry = JObject.Parse(entry.ConvertObjectToJsonString());
             var fieldsToUpdate = (entryToUpdate.Fields as JObject);
 
             foreach (var fieldId in allFieldIds)
@@ -2830,26 +2831,9 @@ namespace Contentful.Core
             return await SendHttpRequest(url, HttpMethod.Get, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
         }
 
-        private string ConvertObjectToJsonString(object ob)
-        {
-            var resolver = new CamelCasePropertyNamesContractResolver();
-            resolver.NamingStrategy.OverrideSpecifiedNames = false;
-
-            var settings = new JsonSerializerSettings
-            {
-                ContractResolver = resolver,
-            };
-
-            settings.Converters.Add(new ExtensionJsonConverter());
-
-            var serializedObject = JsonConvert.SerializeObject(ob, settings);
-
-            return serializedObject;
-        }
-
         private StringContent ConvertObjectToJsonStringContent(object ob)
         {
-            var serializedObject = ConvertObjectToJsonString(ob);
+            var serializedObject = ob.ConvertObjectToJsonString();
             return new StringContent(serializedObject, Encoding.UTF8, "application/vnd.contentful.management.v1+json");
         }
     }

--- a/Contentful.Core/Extensions/JsonConversionExtensions.cs
+++ b/Contentful.Core/Extensions/JsonConversionExtensions.cs
@@ -1,0 +1,32 @@
+using Contentful.Core.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Contentful.Core.Extensions
+{
+    /// <summary>
+    /// Extension methods for Converting Objects to Json
+    /// </summary>
+    public static class JsonConversionExtensions
+    {
+        /// <summary>
+        /// Converts the object to Json to use when sending a parameter in the body of a request to the Contentful API.
+        /// </summary>
+        public static string ConvertObjectToJsonString(this object ob)
+        {
+            var resolver = new CamelCasePropertyNamesContractResolver();
+            resolver.NamingStrategy.OverrideSpecifiedNames = false;
+
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = resolver,
+            };
+
+            settings.Converters.Add(new ExtensionJsonConverter());
+
+            var serializedObject = JsonConvert.SerializeObject(ob, settings);
+
+            return serializedObject;
+        }
+    }
+}

--- a/Contentful.Core/IContentfulClient.cs
+++ b/Contentful.Core/IContentfulClient.cs
@@ -135,6 +135,16 @@ namespace Contentful.Core
         Task<ContentfulCollection<Asset>> GetAssets(string queryString = null, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Creates a key for signing embargoed asset requests.
+        /// </summary>
+        /// <param name="timeOffset">The point in time when the token should expire.</param>
+        /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
+        /// <returns>An instance of <see cref="EmbargoedAssetKey"/> with properties for signing embargoed asset urls.</returns>
+        /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The <see name="timeOffset">timeOffset</see> parameter was in the past or more than 48 hours in the future.</exception>
+        Task<EmbargoedAssetKey> CreateEmargoedAssetKey(DateTimeOffset timeOffset, CancellationToken cancellationToken = default);
+        
+        /// <summary>
         /// Gets the <see cref="Space"/> for this client.
         /// </summary>
         /// <returns>The <see cref="Space"/>.</returns>

--- a/Contentful.Core/Models/EmbargoedAssetKey.cs
+++ b/Contentful.Core/Models/EmbargoedAssetKey.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Contentful.Core.Models
+{
+    /// <summary>
+    /// Represents the parameters needed to sign and make requests for embargoed assets.
+    /// </summary>
+    public class EmbargoedAssetKey
+    {
+        /// <summary>
+        /// The policy parameter to appened to url when requesting an embargoed asset.
+        /// </summary>
+        public string Policy { get; set; }
+        /// <summary>
+        /// The secret parameter to appened to a url when requesting an embargoed asset.
+        /// </summary>
+        public string Secret { get; set; }
+
+        /// <summary>
+        /// The date and time after which the policy and secret will no longer be valid.
+        /// </summary>
+        public DateTime ExpiresAtUtc { get; set; }
+    }
+}


### PR DESCRIPTION
This commit partially addresses issue [267](https://github.com/contentful/contentful.net/issues/267) for supporting embargoed assets. 
The following was done:
- Add a new model representing the embargo asset key, policy and
  expiration
- Add a new method CreateEmbargoedAssetKey which generates a new key with
  a given time to expiry, using the preview or delivery API.
- Added a private equivalent PUT analog to the GET function
- Moved ConvertObjectToStringJson to an extension method so that it can
  be used in the PUT method for both the content and management clients.
- Added unit tests for the moved extension method.
- Added unit tests for the CreateEmbargoedAssetKey method