### PR TITLE
Use non-vulnerable dependencies

### DIFF
--- a/Contentful.AspNetCore/Contentful.AspNetCore.csproj
+++ b/Contentful.AspNetCore/Contentful.AspNetCore.csproj
@@ -39,5 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />    
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Issue is that you are depending on a old and unsupported .NET Core version (2.1), that pulls in dependencies that are vulnerable. Adding explict references avoids that. 

Updating to a newer .NET version may not even solve that.
