### PR TITLE
Ignore CrossSpace links when resolving links

### DIFF
--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -299,6 +299,12 @@ namespace Contentful.Core
             //Walk through and add any included entries as direct links.
             foreach (var linkToken in links)
             {
+                var linkType = ((JValue)linkToken["linkType"]).Value.ToString();
+                if (linkType == "CrossSpaceEntry")
+                {
+                    break;
+                }
+
                 var propName = linkToken.Path.Substring(linkToken.Path.LastIndexOf(".fields.") + 8);
                 propName = propName.Substring(0, propName.IndexOf("."));
                 //remove any [] from propname if it's a collection property

--- a/Contentful.Net.sln
+++ b/Contentful.Net.sln
@@ -1,15 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contentful.Core", "Contentful.Core\Contentful.Core.csproj", "{3E644B4A-7C03-46B7-8877-279A37B8BA74}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contentful.Core.Tests", "Contentful.Core.Tests\Contentful.Core.Tests.csproj", "{94FF525B-0B1B-490E-A862-7B8B3FC065EF}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contentful.AspNetCore", "Contentful.AspNetCore\Contentful.AspNetCore.csproj", "{6D2387D9-B6A7-493E-9837-5CC39188D8B4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contentful.AspNetCore.Tests", "Contentful.AspNetCore.Tests\Contentful.AspNetCore.Tests.csproj", "{43F0B566-83F1-4AD4-933F-FE8D4B80DBB9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,20 +17,15 @@ Global
 		{3E644B4A-7C03-46B7-8877-279A37B8BA74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E644B4A-7C03-46B7-8877-279A37B8BA74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E644B4A-7C03-46B7-8877-279A37B8BA74}.Release|Any CPU.Build.0 = Release|Any CPU
-		{94FF525B-0B1B-490E-A862-7B8B3FC065EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{94FF525B-0B1B-490E-A862-7B8B3FC065EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{94FF525B-0B1B-490E-A862-7B8B3FC065EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94FF525B-0B1B-490E-A862-7B8B3FC065EF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6D2387D9-B6A7-493E-9837-5CC39188D8B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6D2387D9-B6A7-493E-9837-5CC39188D8B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D2387D9-B6A7-493E-9837-5CC39188D8B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D2387D9-B6A7-493E-9837-5CC39188D8B4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{43F0B566-83F1-4AD4-933F-FE8D4B80DBB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{43F0B566-83F1-4AD4-933F-FE8D4B80DBB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{43F0B566-83F1-4AD4-933F-FE8D4B80DBB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{43F0B566-83F1-4AD4-933F-FE8D4B80DBB9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5FD452E-D001-4C71-B6CC-F9AFE8E7F99B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Resolving CrossSpace links fails when selecting tokens for "..sys.linkType" and "..sys.id" because multiple tokens can be found in the crossSpaceEntry-json.
Since this links cannot be resolved anyway, they should be ignored.

LinkType = itemToSkip.SelectToken("$..sys.linkType").Value<string>(),
Id = itemToSkip.SelectToken("$..sys.id").Value<string>()