### PR TITLE
Allow quality parameter for webp images

### DIFF
--- a/Contentful.Core/Images/ImageUrlBuilder.cs
+++ b/Contentful.Core/Images/ImageUrlBuilder.cs
@@ -198,11 +198,16 @@ namespace Contentful.Core.Images
 
                 if(format != "jpg")
                 {
-                    var quality = _querystringValues.FirstOrDefault(c => c.Key == "q");
                     var progressive = _querystringValues.FirstOrDefault(c => c.Key == "fl" && c.Value == "progressive");
 
-                    _querystringValues.Remove(quality);
                     _querystringValues.Remove(progressive);
+                }
+                
+                if(format != "jpg" && format != "webp")
+                {
+                    var quality = _querystringValues.FirstOrDefault(c => c.Key == "q");
+
+                    _querystringValues.Remove(quality);
                 }
             }
         }


### PR DESCRIPTION
Quality is supported on webp images by contentful API, but was removed