### PR TITLE
Pass the MaxDepth from the JsonSetting to the JsonConverter

### DIFF
--- a/Contentful.Core/Configuration/ContentJsonConverter.cs
+++ b/Contentful.Core/Configuration/ContentJsonConverter.cs
@@ -37,6 +37,13 @@ namespace Contentful.Core.Configuration
             if (reader.TokenType == JsonToken.Null) {
                 return null;
             }
+
+            /// Pass through the MaxDepth due to changes in 13.0.1+ which limits to 64
+            // https://stackoverflow.com/a/68580426
+            if (serializer.MaxDepth != null)
+            {
+                reader.MaxDepth = serializer.MaxDepth;
+            }           
             
             var jObject = JObject.Load(reader);
             if (jObject.TryGetValue("$ref", out var refId))


### PR DESCRIPTION
This fix solves the following error we are getting

`Newtonsoft.Json.JsonReaderException: 'The reader's MaxDepth of 64 has been exceeded. Path 'items[0].content.content.content[54].content[0].content[0].content[0].data.target.internalPage.content.content.content[57].content[1].content[0].content[1].data.target.internalPage.content.content.content[53].content[2].content[0].content[1].data.target.internalPage.content.content.content[54].content[3].content[0].content[0].data.target.internalPage.content.content.content[46].content[0].content[0].content[0].marks', line 30654, position 36.'
`