### PR TITLE
Added SelectFields Method To QueryBuilder

### DIFF
--- a/Contentful.Core.Tests/ClientTestsBase.cs
+++ b/Contentful.Core.Tests/ClientTestsBase.cs
@@ -324,4 +324,22 @@ namespace Contentful.Core.Tests
         public Dictionary<string, string> Field34 { get; set; }
         public Dictionary<string, Document> RichText { get; set; }
     }
+
+    public class TestEntry
+    {
+        public SystemProperties Sys { get; set; }
+
+        public string EntryId { get; set; }
+
+        public int Id { get; set; }
+
+        public string Description { get; set; }
+
+        public string Title { get; set; }
+
+        public Document MastHead { get; set; }
+
+        public Asset MainImage { get; set; }
+
+    }
 }

--- a/Contentful.Core.Tests/Extensions/StringContentHelpers.cs
+++ b/Contentful.Core.Tests/Extensions/StringContentHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Contentful.Core.Tests.Extensions
+{
+    public class StringContentHelpers
+    {
+        public static string Encoded(string key, string value)
+        {
+            return $"{key}={System.Net.WebUtility.UrlEncode(value)}";
+        }
+    }
+}

--- a/Contentful.Core.Tests/Search/SelectVisitorTests.cs
+++ b/Contentful.Core.Tests/Search/SelectVisitorTests.cs
@@ -1,0 +1,158 @@
+﻿using Contentful.Core.Models;
+using Contentful.Core.Search;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using static Contentful.Core.Tests.Extensions.StringContentHelpers;
+
+namespace Contentful.Core.Tests.Search
+{
+    public class SelectVisitorTests
+    {
+        [Fact]
+        public void Visitor_GetsField_HasAttributeRename_ShowsInQuery()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntryModel>();
+
+            // Act
+            var qry = builder.SelectFields(x => new { x.SystemMetadata }).Build();
+
+            // Assert
+            Assert.Equal($"?{Encoded("select", "fields.$metadata")}", qry);
+        }
+
+        [Fact]
+        public void Visitor_GetsSysFields_DeeperThanImmediate_Throws()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var testDelegate = () => { builder.SelectFields(x => new { x.Title }, x => new { x.ContentType.Name }); };
+
+            // Assert
+            Assert.Throws<ArgumentException>(testDelegate);
+        }
+
+        [Fact]
+        public void Visitor_GetsRegularFields_DeeperThanImmediate_Throws()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var callback = () => { builder.SelectFields(x => new { x.Title, x.MainImage.TitleLocalized }, true); };
+
+            // Assert
+            Assert.Throws<ArgumentException>(callback);
+        }
+
+        [Fact]
+        public void Visitor_GetsNoFields_IncludesSys_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>().SelectFields<TestEntry>(null, true);
+
+            // Act
+            var request = builder.Build();
+
+            // Assert
+            Assert.Equal($"?select=sys", request);
+        }
+
+        [Fact]
+        public void Visitor_EmptyFieldSelection_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var request = builder.SelectFields(x => new { }).ContentTypeIs("testEntry").Build();
+
+            // Assert
+            Assert.Equal("?content_type=testEntry", request);
+        }
+
+        [Fact]
+        public void Visitor_LocalSysProperty_InFieldsSelections_Throws()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var callback = () => { builder.SelectFields(x => new { x.Sys }); };
+
+            // Assert
+            Assert.Throws<ArgumentException>(callback);
+        }
+
+        [Fact]
+        public void Visitor_FieldsWithEmptySysSelector_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var qry = builder.SelectFields(x => new { x.Title, x.Id, x.MainImage }, x => new { }).Build();
+
+            // Assert
+            Assert.Equal($"?{Encoded("select", "fields.title,fields.id,fields.mainImage")}", qry);
+        }
+
+        [Fact]
+        public void Visitor_FieldsWithNullSysSelector_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var qry = builder.SelectFields<object,SystemProperties>(x => new { x.Title, x.Id, x.MainImage }, null).Build();
+
+            // Assert
+            Assert.Equal($"?{Encoded("select", "fields.title,fields.id,fields.mainImage")}", qry);
+        }
+
+        [Fact]
+        public void Visitor_EmptyFieldsWithSysSelector_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var qry = builder.SelectFields(x => new { }, x => new { x.Id, x.Environment }).Build();
+
+            // Assert
+            Assert.Equal($"?{Encoded("select", "sys.id,sys.environment")}", qry);
+        }
+
+        [Fact]
+        public void Visitor_NullFieldsWithSysSelector_Works()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var qry = builder.SelectFields<object, object>(null, x => new { x.Id, x.Environment }).Build();
+
+            // Assert
+            Assert.Equal($"?{Encoded("select", "sys.id,sys.environment")}", qry);
+        }
+
+        [Fact]
+        public void Visitor_NullFieldsWithNullSysSelector_NoSelect()
+        {
+            // Arrange
+            var builder = new QueryBuilder<TestEntry>();
+
+            // Act
+            var qry = builder.SelectFields<object, SystemProperties>(null, null).Build();
+
+            // Assert
+            Assert.Equal(string.Empty, qry);
+        }
+    }
+}

--- a/Contentful.Core/Contentful.Core.csproj
+++ b/Contentful.Core/Contentful.Core.csproj
@@ -4,7 +4,7 @@
     <PackageId>contentful.csharp</PackageId>
     <AssemblyTitle>contentful.net</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>4.1.1</VersionPrefix>
+    <VersionPrefix>7.2.2</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Contentful</Authors>
     <Copyright>Contentful GmbH.</Copyright>
@@ -18,9 +18,8 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <AssemblyVersion>7.2.2.0</AssemblyVersion>
-    <FileVersion>7.2.2.0</FileVersion>
-    <Version>7.2.2</Version>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="gitlink" Version="3.1.0">

--- a/Contentful.Core/Search/ExpressionHelpers.cs
+++ b/Contentful.Core/Search/ExpressionHelpers.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Contentful.Core.Search
+{
+    public static class ExpressionHelpers
+    {
+        public static string ToCamelCase(this string original)
+        {
+            if (string.IsNullOrWhiteSpace(original))
+            {
+                return string.Empty;
+            }
+
+            if (original.ToUpperInvariant() == original)
+            {
+                // is all uppercase, bail as acronym
+                return original;
+            }
+
+            // will check each character in order and the first one that is lower will engage fail-fast which accumulates speed.
+            // in testing this massively outperforms regex.replace and StringBuilder.Append with bounded limits (the way to concatenate lower change + existing remainder w/o substring)
+            bool isAtBeginning = true;
+            string converted = new(original.Select(s =>
+            {
+                if (!isAtBeginning)
+                {
+                    return s;
+                }
+
+                if (char.IsUpper(s) && isAtBeginning)
+                {
+                    return char.ToLowerInvariant(s);
+                }
+
+                if (char.IsLower(s) && isAtBeginning)
+                {
+                    isAtBeginning = false;
+                }
+                return s;
+            }).ToArray());
+            return converted;
+        }
+    }
+}

--- a/Contentful.Core/Search/SelectVisitor.cs
+++ b/Contentful.Core/Search/SelectVisitor.cs
@@ -1,0 +1,70 @@
+﻿using Contentful.Core.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Contentful.Core.Search
+{
+    internal class SelectVisitor : ExpressionVisitor
+    {
+        private readonly Type _sourceType;
+        private readonly string _prefix;
+
+        public string FieldName { get; private set; }
+
+
+        public SelectVisitor(Type sourceType) {
+            _sourceType = sourceType;
+            _prefix = sourceType == typeof(SystemProperties) ? "sys" : "fields";
+        }
+
+        public void Reset()
+        {
+            FieldName = string.Empty;
+        }
+
+        public override Expression Visit(Expression node)
+        {
+            return base.Visit(node);
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node?.Expression == null) {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            if (node.Expression.NodeType != ExpressionType.Parameter)
+            {
+                throw new ArgumentException("The only valid member expressions have to be immediate children of the entry type", nameof(node));
+            }
+
+            if (node.Type == typeof(SystemProperties))
+            {
+                throw new ArgumentException("The sys properties cannot be mixed in with the fields properties to select", nameof(node));
+            }
+
+            var jsonProp = node.Member.GetCustomAttributes(true).OfType<JsonPropertyAttribute>().FirstOrDefault();
+
+            var converted = !string.IsNullOrWhiteSpace(jsonProp?.PropertyName) ?
+                            jsonProp.PropertyName :
+                            node.Member.Name.ToCamelCase();
+
+            FieldName = $"{_prefix}.{converted}";
+            return Visit(node.Expression);
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (node.Type != _sourceType)
+            {
+                throw new InvalidOperationException($"The member used must belong to the {_sourceType.Name} type");
+            }
+
+            return node;
+        }
+    }
+}


### PR DESCRIPTION
To implement per the HTTP API for selecting fields 
[API](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters)
but with a focus of applying as much of the validation through .Net exceptions as possible -- to limit runtime errors.

The main changes were:

* added the SelectFields calls to QueryBuilder<T>
* added tests covering every scenario that I thought of
* followed the spec on the API doc pages for the HTTP API
* added comments in code to ensure flow is manageable
* implemented an Expression Visitor to make use of the best practices for affecting and walking the Linq Expressions AST

I did add a comment that I had noticed the csproj file had the VersionPrefix set to 4.1.1, yet was using 7.2.2 on the effective fields below that.  If you have not yet tried it, managing the version with `dotnet pack -o <your_locals_folder> --version-suffix <some-word-or-number>` is handy, as well as the built in tooling from MS uses VersionPrefix and VersionSuffix to generate the <Version> value as it is.  The above call builds out the lib as contentful.net-7.2.2-prerelease-word.nupkg -- so producing a prerelease workflow is much less painful.  

I can revert that change if needed, I just figured in the very least - using VersionPrefix and VersionSuffix the way I have it allows you to avoid hard Version tagging, and run the pack workflow more automatically (being able to use the dotnet cli as well as VS)

If there are any areas I did not test well enough or any sections that would need added for documentation, I would be more than happy to amend the pull request if desired.

Thanks again!