### PR TITLE
Correctly deserialize sub- and superscript enabled marks

### DIFF
--- a/Contentful.Core.Tests/JsonFiles/ContenttypesCollectionManagement.json
+++ b/Contentful.Core.Tests/JsonFiles/ContenttypesCollectionManagement.json
@@ -590,7 +590,10 @@
               "enabledMarks": [
                 "bold",
                 "italic",
-                "underline"
+                "underline",
+                "code",
+                "superscript",
+                "subscript"
               ],
               "message": "Only bold, italic, and underline marks are allowed"
             },

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -41,7 +41,15 @@ namespace Contentful.Core.Models.Management
         /// <summary>
         /// Code.
         /// </summary>
-        code
+        code,
+        /// <summary>
+        /// Superscript.
+        /// </summary>
+        superscript,
+        /// <summary>
+        /// Subscript.
+        /// </summary>
+        subscript
     }
 
     /// <summary>


### PR DESCRIPTION
This is a fix for #309. This currently breaks some of our customers in production, so I would appreciate it it someone can look at that and release a new version of the NuGet package fairly urgently 🙏 