### PR TITLE
Set SystemProperties.Environment to null after UploadFile call

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -2119,6 +2119,7 @@ namespace Contentful.Core
             upload.SystemProperties.CreatedAt = null;
             upload.SystemProperties.CreatedBy = null;
             upload.SystemProperties.Space = null;
+            upload.SystemProperties.Environment = null;
             upload.SystemProperties.LinkType = "Upload";
             foreach (var file in asset.Files)
             {


### PR DESCRIPTION
This proposes to fix a validation error that occurs when calling UploadFileAndCreateAsset by setting the SystemProperties.Environment property back to null. The result from UploadFile has the SystemProperties.Environment set and this causes a validation error.