### PR TITLE
Add 'strikethrough' value to EnabledMarkRestrictions enum

### DIFF
--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -49,7 +49,11 @@ namespace Contentful.Core.Models.Management
         /// <summary>
         /// Subscript.
         /// </summary>
-        subscript
+        subscript,
+        /// <summary>
+        /// Strikethrough.
+        /// </summary>
+        strikethrough
     }
 
     /// <summary>


### PR DESCRIPTION
Contentful API fails to deserialize Content Types and throws:

System.ArgumentException: 'Requested value 'strikethrough' was not found.'

The EnabledMarkRestrictions should contain a 'strikethrough' value.