### PR TITLE
A more accurate resolving of references

### DIFF
--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -390,8 +390,13 @@ namespace Contentful.Core
                         //This could be due to the referenced entry being part of the original request (circular reference), so scan through that as well.
                         replacementToken = json.SelectTokens($"$.items.[?(@.sys.id=='{linkId}')]").FirstOrDefault();
                     }
-
-
+                } 
+                else if (processedIds.Contains(linkId))
+                {
+                    replacementToken = new JObject
+                    {
+                        ["$ref"] = linkId
+                    };
                 }
 
                 var grandParent = (JObject)linkToken.Parent.Parent;
@@ -413,7 +418,7 @@ namespace Contentful.Core
                         }
                     }
 
-                    if (!processedIds.Contains(linkId))
+                    if (!scopedIds.Contains(linkId))
                     {
                         Type propType = null;
 


### PR DESCRIPTION
To extend upon our earlier suggested fix, this wasn't fully covering it, missed an if-statement. Fixing this did result in 2 failing tests related to cross-space references which we fixed by adding a third if-else branch that originally existed as the first branch in that same if-else-block.

ps. we did NOT write any tests, we would appreciate it if team Contentful would eventually cover it with unit tests