### PR TITLE
Bug/asset hyperlink

### DIFF
--- a/Contentful.Core/Configuration/ContentJsonConverter.cs
+++ b/Contentful.Core/Configuration/ContentJsonConverter.cs
@@ -74,6 +74,7 @@ namespace Contentful.Core.Configuration
                 case "hyperlink":
                     return jObject.ToObject<Hyperlink>(serializer);
                 case "asset-hyperlink":
+                    return jObject.ToObject<AssetHyperlink>(serializer);
                 case "embedded-asset-inline":
                 case "embedded-asset-block":
                     return jObject.ToObject<AssetStructure>(serializer);


### PR DESCRIPTION
An `AssetHyperlink` class did exist, but wasn't used in `ContentJsonConverter`. This would be technically a **breaking change**. The reason why we would prefer this way is to avoid having to deal with strange patternmatchings on `AssetStructure` while the expected type should actually be `AssetHyperlink`. Added a new renderer for good measure (we don't actually use this renderer, but the tests failed, so it felt appropiate)
@Roblinde  