### PR TITLE
Reverted proposed changes + ResolveEntriesSelectively change

### DIFF
--- a/Contentful.Core.Tests/ContentfulClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulClientTests.cs
@@ -1300,7 +1300,9 @@ namespace Contentful.Core.Tests
             _handler.Response = GetResponseFromFile(@"EntryCollectionLoopedReferences.json");
 
             //Act
+            _client.ResolveEntriesSelectively = true;
             var entries = await _client.GetEntries<ContentfulEvent>();
+            _client.ResolveEntriesSelectively = false;
             var nulls = entries.Where(c => c.Image == null).ToList();
 
             //Assert
@@ -1321,7 +1323,9 @@ namespace Contentful.Core.Tests
             _client.ContentTypeResolver = new TestResolver();
 
             //Act
+            _client.ResolveEntriesSelectively = true;
             var entries = await _client.GetEntries<IMarker>();
+            _client.ResolveEntriesSelectively = false;
             var nulls = entries.Where(c => (c as ContentfulEvent).Image == null).ToList();
 
             //Assert
@@ -1355,7 +1359,9 @@ namespace Contentful.Core.Tests
             _handler.Response = GetResponseFromFile(@"NestedSharedStructure.json");
 
             //Act
+            _client.ResolveEntriesSelectively = true;
             var res = await _client.GetEntries<TestNestedSharedItem>();
+            _client.ResolveEntriesSelectively = false;
 
             //Assert
             Assert.Single(res);
@@ -1371,7 +1377,9 @@ namespace Contentful.Core.Tests
             _client.ContentTypeResolver = new TestResolver();
 
             //Act
+            _client.ResolveEntriesSelectively = true;
             var res = await _client.GetEntries<IMarker>();
+            _client.ResolveEntriesSelectively = false;
 
             //Assert
             Assert.Single(res);

--- a/Contentful.Core/IContentfulClient.cs
+++ b/Contentful.Core/IContentfulClient.cs
@@ -33,6 +33,11 @@ namespace Contentful.Core
         public JsonSerializer Serializer { get; }
 
         /// <summary>
+        /// If set the GetEntries methods will evaluate the class to serialize into and only serialize the parts that are part of the class structure.
+        /// </summary>
+        bool ResolveEntriesSelectively { get; set; }
+
+        /// <summary>
         /// Settings for the spaces to resolve cross space references from.
         /// </summary>
         List<CrossSpaceResolutionSetting> CrossSpaceResolutionSettings { get; set; }


### PR DESCRIPTION
I've reverted the previous proposed change for an attempted solution. Additionally I've brought back the ResolveEntriesSelectively in lieue of coming up with a different solution.

For our purposes the SDK already offered a solution, althought this wasn't clarified to us, in the form of an `IContentTypeResolver`. Because we auto-generate our models, having an `IContentTypeResolver` implementation solved our issues. The reason why we needed this resolver, is because Newtonsoft would skip over unknown types, which may hold important $id metadata, this resulted in $ref's not being resolved. I would suggest to have customers save debugging time by giving the `IContentTypeResolver` approach a more prominent stage.

The scopedIds approach seems like a good approach on paper, but it potentially results in having duplicate $id metadata which (understandably) confuses Newtonsoft and throws an exception. Also in having to debug this extensively I can see merit in the approach which existed before our proposal. 

Bringing back the ResolveEntriesSelectively wasn't necessary for our project, as we autogenerate models and thus our models are predictable, but it did result in four tests failing. As I looked into the reason for this, it clicked for me that with ResolveEntriesSelectively you're taking into account the current type that is being handled, which seems like a correct approach to me. My investigation has stopped at this point, as I've brought back the SDK in a state where both my project runs and all the unit tests as expected.