### PR TITLE
ContentfulClient tweaks

### DIFF
--- a/Contentful.AspNetCore/IServiceCollectionExtensions.cs
+++ b/Contentful.AspNetCore/IServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Contentful.Core.Configuration;
@@ -8,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using System.Net.Http;
 using Contentful.Core;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Http;
 using Contentful.Core.Models;
 
 namespace Contentful.AspNetCore
@@ -31,7 +28,17 @@ namespace Contentful.AspNetCore
             services.AddOptions();
             services.Configure<ContentfulOptions>(configuration.GetSection("ContentfulOptions"));
             services.TryAddSingleton<HttpClient>();
-            services.AddHttpClient(HttpClientName);
+            services.AddHttpClient(HttpClientName);// TODO: When contentful.csharp has been updated, remove this line & uncomment below code to effectuate HTTP Response compression
+            // services.AddHttpClient(HttpClientName).ConfigurePrimaryHttpMessageHandler(sp =>
+            // {
+            //     var options = sp.GetService<IOptions<ContentfulOptions>>().Value;
+            //     var handler = new HttpClientHandler();
+            //     if (options.AllowHttpResponseCompression && handler.SupportsAutomaticDecompression)
+            //     {
+            //         handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            //     }
+            //     return handler;
+            // });
             services.TryAddTransient<IContentfulClient>((sp) => {
                 var options = sp.GetService<IOptions<ContentfulOptions>>().Value;
                 var factory = sp.GetService<IHttpClientFactory>();

--- a/Contentful.Core/Configuration/ContentfulOptions.cs
+++ b/Contentful.Core/Configuration/ContentfulOptions.cs
@@ -56,5 +56,11 @@ namespace Contentful.Core.Configuration
         /// Default is "https://cdn.contentful.com/spaces/".
         /// </summary>
         public string BaseUrl { get; set; } = "https://cdn.contentful.com/spaces/";
+
+        /// <summary>
+        /// Whether to use HTTP compression for responses. Only disable if you are hosting in the same datacenter as contentful
+        /// Default is true
+        /// </summary>
+        public bool AllowHttpResponseCompression { get; set; } = true;
     }
 }

--- a/Contentful.Core/Configuration/ExtensionJsonConverter.cs
+++ b/Contentful.Core/Configuration/ExtensionJsonConverter.cs
@@ -4,9 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Contentful.Core.Configuration
 {
@@ -15,6 +13,17 @@ namespace Contentful.Core.Configuration
     /// </summary>
     public class ExtensionJsonConverter : JsonConverter
     {
+        private static readonly JsonSerializerSettings JsonSerializerSettings = new()
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver
+            {
+                NamingStrategy =
+                {
+                    OverrideSpecifiedNames = false
+                }
+            },
+        };
+
         /// <summary>
         /// Determines whether this instance can convert the specified object type.
         /// </summary>
@@ -75,15 +84,7 @@ namespace Contentful.Core.Configuration
                 extension
             };
 
-            var resolver = new CamelCasePropertyNamesContractResolver();
-            resolver.NamingStrategy.OverrideSpecifiedNames = false;
-
-            var settings = new JsonSerializerSettings
-            {
-                ContractResolver = resolver,
-            };
-
-            var jObject = JObject.FromObject(extensionStructure, JsonSerializer.Create(settings));
+            var jObject = JObject.FromObject(extensionStructure, JsonSerializer.Create(JsonSerializerSettings));
 
             serializer.Serialize(writer, jObject);
         }

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -134,7 +134,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries/{entryId}{queryString}", etag, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries/{entryId}{queryString}", etag, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
 
             if(!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -218,14 +218,14 @@ namespace Contentful.Core
 
         public async Task<string> GetEntriesRaw(string queryString = null, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries{queryString}", null, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries{queryString}", null, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
             var resultString = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
             return resultString;
         }
 
         public async Task<ContentfulResult<ContentfulCollection<T>>> GetEntries<T>(string etag, string queryString = null, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries{queryString}", etag, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}entries{queryString}", etag, cancellationToken, CrossSpaceResolutionSettings).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag.Tag == etag)
             {
@@ -496,7 +496,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}assets/{assetId}{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}assets/{assetId}{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -547,7 +547,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulResult<ContentfulCollection<Asset>>> GetAssets(string etag, string queryString = null, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}assets/{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}assets/{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -613,7 +613,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulResult<Space>> GetSpace(string etag, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -655,7 +655,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -675,7 +675,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentTag"/>.</returns>
         public async Task<IEnumerable<ContentTag>> GetTags(string queryString = "", CancellationToken cancellationToken = default) {
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{queryString}", null, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{queryString}", null, cancellationToken, null).ConfigureAwait(false);
 
             var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
             var tags = jsonObject.SelectTokens("$..items[*]").Select(t => t.ToObject<ContentTag>(Serializer));
@@ -696,7 +696,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(tagId));
             }
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{tagId}", null, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{tagId}", null, cancellationToken, null).ConfigureAwait(false);
 
             var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
             var tag = jsonObject.ToObject<ContentTag>(Serializer);
@@ -737,7 +737,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
         public async Task<ContentfulResult<IEnumerable<ContentType>>> GetContentTypes(string etag, string queryString, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}content_types/{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}content_types/{queryString}", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -770,7 +770,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Locale"/>.</returns>
         public async Task<ContentfulResult<IEnumerable<Locale>>> GetLocales(string etag, CancellationToken cancellationToken = default)
         {
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{(string.IsNullOrEmpty(EnvironmentsBase) ? "environments/master/" : EnvironmentsBase)}locales/", etag, cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{(string.IsNullOrEmpty(EnvironmentsBase) ? "environments/master/" : EnvironmentsBase)}locales/", etag, cancellationToken, null).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(etag) && res.Headers?.ETag?.Tag == etag)
             {
@@ -815,7 +815,7 @@ namespace Contentful.Core
 
             var query = BuildSyncQuery(syncType, contentTypeId, true, limit: limit);
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}sync{query}", "", cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}sync{query}", "", cancellationToken, null).ConfigureAwait(false);
 
             var syncResult = ParseSyncResult(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
 
@@ -842,7 +842,7 @@ namespace Contentful.Core
 
             var query = BuildSyncQuery(syncToken: syncToken);
 
-            var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}sync{query}", "", cancellationToken, null).ConfigureAwait(false);
+            using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}sync{query}", "", cancellationToken, null).ConfigureAwait(false);
 
             var syncResult = ParseSyncResult(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
 

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -109,9 +109,9 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into <typeparamref name="T"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The entryId parameter was null or empty.</exception>
-        public async Task<T> GetEntry<T>(string entryId, QueryBuilder<T> queryBuilder, CancellationToken cancellationToken = default)
+        public Task<T> GetEntry<T>(string entryId, QueryBuilder<T> queryBuilder, CancellationToken cancellationToken = default)
         {
-            return await GetEntry<T>(entryId, queryBuilder?.Build(), cancellationToken).ConfigureAwait(false);
+            return GetEntry<T>(entryId, queryBuilder?.Build(), cancellationToken);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Contentful.Core
                 return new ContentfulResult<T>(res.Headers?.ETag?.Tag, default(T));
             }
 
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var json = await res.GetJObjectFromResponse().ConfigureAwait(false);
 
             JToken entry;
 
@@ -211,9 +211,9 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of items.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<T>> GetEntries<T>(QueryBuilder<T> queryBuilder, CancellationToken cancellationToken = default)
+        public Task<ContentfulCollection<T>> GetEntries<T>(QueryBuilder<T> queryBuilder, CancellationToken cancellationToken = default)
         {
-            return await GetEntries<T>(queryBuilder?.Build(), cancellationToken).ConfigureAwait(false);
+            return GetEntries<T>(queryBuilder?.Build(), cancellationToken);
         }
 
         public async Task<string> GetEntriesRaw(string queryString = null, CancellationToken cancellationToken = default)
@@ -232,7 +232,7 @@ namespace Contentful.Core
                 return new ContentfulResult<ContentfulCollection<T>>(res.Headers?.ETag?.Tag, null);
             }
 
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var json = await res.GetJObjectFromResponse().ConfigureAwait(false);
 
             ReplaceMetaData(json);
 
@@ -475,9 +475,9 @@ namespace Contentful.Core
         /// <returns>The response from the API serialized into an <see cref="Asset"/></returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         /// <exception cref="ArgumentException">The <see name="assetId">assetId</see> parameter was null or emtpy.</exception>
-        public async Task<Asset> GetAsset(string assetId, QueryBuilder<Asset> queryBuilder, CancellationToken cancellationToken = default)
+        public Task<Asset> GetAsset(string assetId, QueryBuilder<Asset> queryBuilder, CancellationToken cancellationToken = default)
         {
-            return await GetAsset(assetId, queryBuilder?.Build(), cancellationToken);
+            return GetAsset(assetId, queryBuilder?.Build(), cancellationToken);
         }
 
         /// <summary>
@@ -503,8 +503,7 @@ namespace Contentful.Core
                 return new ContentfulResult<Asset>(res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var asset = jsonObject.ToObject<Asset>(Serializer);
+            var asset = await res.GetObjectFromResponse<Asset>(Serializer).ConfigureAwait(false);
 
             return new ContentfulResult<Asset>(res.Headers?.ETag?.Tag, asset);
         }
@@ -532,9 +531,9 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of <see cref="Asset"/>.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<Asset>> GetAssets(QueryBuilder<Asset> queryBuilder, CancellationToken cancellationToken = default)
+        public Task<ContentfulCollection<Asset>> GetAssets(QueryBuilder<Asset> queryBuilder, CancellationToken cancellationToken = default)
         {
-            return await GetAssets(queryBuilder?.Build(), cancellationToken).ConfigureAwait(false);
+            return GetAssets(queryBuilder?.Build(), cancellationToken);
         }
 
         /// <summary>
@@ -554,7 +553,7 @@ namespace Contentful.Core
                 return new ContentfulResult<ContentfulCollection<Asset>>(res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await res.GetJObjectFromResponse().ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<Asset>>(Serializer);
             var assets = jsonObject.SelectTokens("$.items[*]").Select(c => c.ToObject<Asset>(Serializer)); ;
             collection.Items = assets;
@@ -599,8 +598,7 @@ namespace Contentful.Core
             //note that unlike some other api methods, the asset embargo key always requires an environment id.
             var res = await Post($"{BaseUrl}{_options.SpaceId}/{(EnvironmentsBase == string.Empty ? "environments/master/" : EnvironmentsBase)}asset_keys", new { expiresAt }, cancellationToken).ConfigureAwait(false);
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var assetKey = jsonObject.ToObject<EmbargoedAssetKey>(Serializer);
+            var assetKey = await res.GetObjectFromResponse<EmbargoedAssetKey>(Serializer).ConfigureAwait(false);
             assetKey.ExpiresAtUtc = timeOffset.UtcDateTime;
             return assetKey;
         }
@@ -620,8 +618,7 @@ namespace Contentful.Core
                 return new ContentfulResult<Space>(res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var space = jsonObject.ToObject<Space>(Serializer);
+            var space = await res.GetObjectFromResponse<Space>(Serializer).ConfigureAwait(false);
 
             return new ContentfulResult<Space>(res.Headers?.ETag?.Tag, space);
         }
@@ -662,8 +659,7 @@ namespace Contentful.Core
                 return new ContentfulResult<ContentType>(res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var contentType = jsonObject.ToObject<ContentType>(Serializer);
+            var contentType = await res.GetObjectFromResponse<ContentType>(Serializer).ConfigureAwait(false);
 
             return new ContentfulResult<ContentType>(res.Headers?.ETag?.Tag, contentType);
         }
@@ -677,7 +673,7 @@ namespace Contentful.Core
 
             using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{queryString}", null, cancellationToken, null).ConfigureAwait(false);
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await res.GetJObjectFromResponse().ConfigureAwait(false);
             var tags = jsonObject.SelectTokens("$..items[*]").Select(t => t.ToObject<ContentTag>(Serializer));
 
             return tags;
@@ -698,8 +694,7 @@ namespace Contentful.Core
 
             using var res = await Get($"{BaseUrl}{_options.SpaceId}/{EnvironmentsBase}tags/{tagId}", null, cancellationToken, null).ConfigureAwait(false);
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var tag = jsonObject.ToObject<ContentTag>(Serializer);
+            var tag = await res.GetObjectFromResponse<ContentTag>(Serializer).ConfigureAwait(false);
 
             return tag;
         }
@@ -724,9 +719,9 @@ namespace Contentful.Core
         /// </summary>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
-        public async Task<IEnumerable<ContentType>> GetContentTypes(CancellationToken cancellationToken = default)
+        public Task<IEnumerable<ContentType>> GetContentTypes(CancellationToken cancellationToken = default)
         {
-            return await GetContentTypes(null, cancellationToken);
+            return GetContentTypes(null, cancellationToken);
         }
 
         /// <summary>
@@ -744,7 +739,7 @@ namespace Contentful.Core
                 return new ContentfulResult<IEnumerable<ContentType>>(res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await res.GetJObjectFromResponse().ConfigureAwait(false);
             var contentTypes = jsonObject.SelectTokens("$..items[*]").Select(t => t.ToObject<ContentType>(Serializer));
 
             return new ContentfulResult<IEnumerable<ContentType>>(res.Headers?.ETag?.Tag, contentTypes);
@@ -777,7 +772,7 @@ namespace Contentful.Core
                 return new ContentfulResult<IEnumerable<Locale>> (res.Headers?.ETag?.Tag, null);
             }
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await res.GetJObjectFromResponse().ConfigureAwait(false);
             var locales = jsonObject.SelectTokens("$..items[*]").Select(t => t.ToObject<Locale>(Serializer));
 
             return new ContentfulResult<IEnumerable<Locale>>(res.Headers?.ETag?.Tag, locales);

--- a/Contentful.Core/ContentfulClientBase.cs
+++ b/Contentful.Core/ContentfulClientBase.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Contentful.Core.Extensions;
 
 namespace Contentful.Core
 {
@@ -276,6 +277,25 @@ namespace Contentful.Core
             {
                 message.Headers.Add("X-Contentful-Version", version.ToString());
             }
+        }
+
+        /// <summary>Returns an object of type T from the response, if the response is successful</summary>
+        /// <param name="response">The response to deserialize</param>
+        /// <typeparam name="T">The type that should be returned</typeparam>
+        /// <returns>The deserialized object</returns>
+        protected async Task<T> GetObjectFromResponse<T>(HttpResponseMessage response)
+        {
+            await EnsureSuccessfulResult(response).ConfigureAwait(false);
+            return await response.GetObjectFromResponse<T>(Serializer).ConfigureAwait(false);
+        }
+
+        /// <summary>Returns a JObject from the response, if the response is successful</summary>
+        /// <param name="response">The response to deserialize</param>
+        /// <returns>The deserialized JObject</returns>
+        protected async Task<JObject> GetJObjectFromResponse(HttpResponseMessage response)
+        {
+            await EnsureSuccessfulResult(response).ConfigureAwait(false);
+            return await response.GetJObjectFromResponse().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Contentful.Core/ContentfulClientBase.cs
+++ b/Contentful.Core/ContentfulClientBase.cs
@@ -106,9 +106,7 @@ namespace Contentful.Core
                 message += errorDetails.Errors?.ToString();
             }
 
-            IEnumerable<string> headers;
-
-            if(statusCode == 429 && res.Headers.TryGetValues("X-Contentful-RateLimit-Reset", out headers))
+            if (statusCode == 429 && res.Headers.TryGetValues("X-Contentful-RateLimit-Reset", out var headers))
             {
                 var rateLimitException = new ContentfulRateLimitException(message)
                 {
@@ -223,7 +221,7 @@ namespace Contentful.Core
         protected async Task<HttpResponseMessage> SendHttpRequest(string url, HttpMethod method, string authToken, CancellationToken cancellationToken, HttpContent content = null, 
             int? version = null, string contentTypeId = null, string organisationId = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
-            var httpRequestMessage = new HttpRequestMessage()
+            using var httpRequestMessage = new HttpRequestMessage
             {
                 RequestUri = new Uri(url),
                 Method = method

--- a/Contentful.Core/ContentfulClientBase.cs
+++ b/Contentful.Core/ContentfulClientBase.cs
@@ -305,7 +305,7 @@ namespace Contentful.Core
                             await Task.Delay(ex.SecondsUntilNextRequest * 1000).ConfigureAwait(false);
                         }
                        
-                        var clonedMessage = await CloneHttpRequest(response.RequestMessage);
+                        using var clonedMessage = await CloneHttpRequest(response.RequestMessage);
 
                         response = await _httpClient.SendAsync(clonedMessage, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 

--- a/Contentful.Core/ContentfulClientBase.cs
+++ b/Contentful.Core/ContentfulClientBase.cs
@@ -49,6 +49,7 @@ namespace Contentful.Core
         public string Version => InformationalVersion;
 
         private static readonly string Os = IsWindows ? "Windows" : IsMacOS ? "macOS" : "Linux";
+        private static readonly Version HttpVersion2 = new(2,0);
 
         private const string Platform = ".net";
 
@@ -224,6 +225,7 @@ namespace Contentful.Core
         {
             using var httpRequestMessage = new HttpRequestMessage
             {
+                Version = HttpVersion2,
                 RequestUri = new Uri(url),
                 Method = method
             };
@@ -345,7 +347,7 @@ namespace Contentful.Core
         private static async Task<HttpRequestMessage> CloneHttpRequest(HttpRequestMessage message)
         {
             var clone = new HttpRequestMessage(message.Method, message.RequestUri);
-
+            clone.Version = message.Version;
             // Copy the request's content (via a MemoryStream) into the cloned object
             if (message.Content != null)
             {

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -4,9 +4,7 @@ using Contentful.Core.Extensions;
 using Contentful.Core.Models;
 using Contentful.Core.Models.Management;
 using Contentful.Core.Search;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,7 +72,7 @@ namespace Contentful.Core
         /// <returns>The created <see cref="Space"/></returns>
         public async Task<Space> CreateSpace(string name, string defaultLocale, string organisation = null, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync(_baseUrl, ConvertObjectToJsonStringContent(new { name, defaultLocale }), cancellationToken, null, organisationId: organisation).ConfigureAwait(false);
+            using var res = await PostAsync(_baseUrl, ConvertObjectToJsonStringContent(new { name, defaultLocale }), cancellationToken, null, organisationId: organisation).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -106,7 +104,7 @@ namespace Contentful.Core
         /// <returns>The updated <see cref="Space"/></returns>
         public async Task<Space> UpdateSpaceName(string id, string name, int version, string organisation = null, CancellationToken cancellationToken = default)
         {
-            var res = await PutAsync($"{_baseUrl}{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version, organisationId: organisation).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version, organisationId: organisation).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -123,7 +121,7 @@ namespace Contentful.Core
         /// <returns>The <see cref="Space" /></returns>
         public async Task<Space> GetSpace(string id, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{id}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{id}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -139,7 +137,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Space"/>.</returns>
         public async Task<IEnumerable<Space>> GetSpaces(CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync(_baseUrl, cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync(_baseUrl, cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -156,7 +154,7 @@ namespace Contentful.Core
         /// <returns></returns>
         public async Task DeleteSpace(string id, CancellationToken cancellationToken = default)
         {
-            var res = await DeleteAsync($"{_baseUrl}{id}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{id}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -181,7 +179,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
         public async Task<IEnumerable<ContentType>> GetContentTypes(string queryString, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -215,7 +213,7 @@ namespace Contentful.Core
                 Metadata = contentType.Metadata,
                 Name = contentType.Name,
             };
-            var res = await PutAsync(baseUrl,
+            using var res = await PutAsync(baseUrl,
                 ConvertObjectToJsonStringContent(clone),
                 cancellationToken, version).ConfigureAwait(false);
 
@@ -242,7 +240,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -268,7 +266,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -290,7 +288,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/published", null, cancellationToken, version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -316,7 +314,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/published", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/published", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -341,7 +339,7 @@ namespace Contentful.Core
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
         public async Task<IEnumerable<ContentType>> GetActivatedContentTypes(string queryString, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/content_types/{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/content_types/{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -366,7 +364,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTypeId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -396,7 +394,7 @@ namespace Contentful.Core
             // not allowed to pass sys properties on the update call for some reason
             editorInterface.SystemProperties = null;
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface",
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface",
                 ConvertObjectToJsonStringContent(editorInterface), cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -477,7 +475,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<T>> GetEntriesCollection<T>(string queryString = null, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -530,7 +528,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The content type id must be set.", nameof(contentTypeId));
             }
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries",
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries",
                 ConvertObjectToJsonStringContent(new { fields = entry.Fields, metadata = entry.Metadata }), cancellationToken, null, contentTypeId).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -576,7 +574,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the entry must be set.");
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entry.SystemProperties.Id}",
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entry.SystemProperties.Id}",
                 ConvertObjectToJsonStringContent(new { fields = entry.Fields, metadata = entry.Metadata }), cancellationToken, version, contentTypeId).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -661,8 +659,8 @@ namespace Contentful.Core
         /// <returns>The updated <see cref="Entry{T}"/>.</returns>
         public async Task<Entry<dynamic>> UpdateEntryForLocale(object entry, string id, string locale = null, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var entryToUpdate = await GetEntry(id, spaceId);
-            var contentType = await GetContentType(entryToUpdate.SystemProperties.ContentType.SystemProperties.Id, spaceId);
+            var entryToUpdate = await GetEntry(id, spaceId, cancellationToken);
+            var contentType = await GetContentType(entryToUpdate.SystemProperties.ContentType.SystemProperties.Id, spaceId, cancellationToken);
             var allFieldIds = contentType.Fields.Select(f => f.Id);
 
             if (string.IsNullOrEmpty(locale))
@@ -707,7 +705,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -737,7 +735,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -759,7 +757,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", null, cancellationToken, version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -783,7 +781,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -807,7 +805,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", null, cancellationToken, version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", null, cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -831,7 +829,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(entryId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -861,7 +859,7 @@ namespace Contentful.Core
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(string queryString = null, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -882,7 +880,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ManagementAsset>> GetPublishedAssetsCollection(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/assets", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/assets", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -910,7 +908,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -935,7 +933,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -957,7 +955,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", null, cancellationToken, version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -983,7 +981,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1037,7 +1035,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(assetId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/archived", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/archived", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1126,7 +1124,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the asset must be set.");
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{asset.SystemProperties.Id}",
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{asset.SystemProperties.Id}",
                 ConvertObjectToJsonStringContent(new
                 {
                     fields = new { title = asset.Title, description = asset.Description, file = asset.Files },
@@ -1152,7 +1150,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ManagementAsset> CreateAsset(ManagementAsset asset, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets",
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets",
                 ConvertObjectToJsonStringContent(new { fields = new { title = asset.Title, description = asset.Description, file = asset.Files } }), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -1172,7 +1170,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<Locale>> GetLocalesCollection(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res);
 
@@ -1194,7 +1192,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<Locale> CreateLocale(Locale locale, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales",
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales",
                 ConvertObjectToJsonStringContent(
                     new
                     {
@@ -1229,7 +1227,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The localeId must be set.");
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{localeId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{localeId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1253,7 +1251,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the Locale must be set.");
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{locale.SystemProperties.Id}", ConvertObjectToJsonStringContent(new
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{locale.SystemProperties.Id}", ConvertObjectToJsonStringContent(new
             {
                 code = locale.Code,
                 contentDeliveryApi = locale.ContentDeliveryApi,
@@ -1285,7 +1283,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The localeId must be set.");
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{localeId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{localeId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -1300,7 +1298,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<Webhook>> GetWebhooksCollection(string spaceId = null, string queryString = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1325,7 +1323,7 @@ namespace Contentful.Core
             //Not allowed to post system properties
             webhook.SystemProperties = null;
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions", ConvertObjectToJsonStringContent(webhook), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions", ConvertObjectToJsonStringContent(webhook), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1356,7 +1354,7 @@ namespace Contentful.Core
             //Not allowed to post system properties
             webhook.SystemProperties = null;
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{id}", ConvertObjectToJsonStringContent(webhook), cancellationToken, version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{id}", ConvertObjectToJsonStringContent(webhook), cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1381,7 +1379,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the webhook must be set.", nameof(webhookId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{webhookId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{webhookId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1405,7 +1403,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the webhook must be set", nameof(webhookId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{webhookId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{webhookId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -1426,7 +1424,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the webhook must be set.", nameof(webhookId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1460,7 +1458,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the webhook must be set.", nameof(webhookId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls/{callId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls/{callId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1485,7 +1483,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the webhook must be set.", nameof(webhookId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/health", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/health", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1515,7 +1513,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the role must be set", nameof(roleId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{roleId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{roleId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1533,7 +1531,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<Role>> GetAllRoles(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1558,7 +1556,7 @@ namespace Contentful.Core
             //Not allowed to post system properties
             role.SystemProperties = null;
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1588,7 +1586,7 @@ namespace Contentful.Core
             //Not allowed to post system properties
             role.SystemProperties = null;
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{id}", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{id}", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1612,7 +1610,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the role must be set", nameof(roleId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{roleId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{roleId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -1631,7 +1629,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the entry must be set", nameof(entryId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1663,7 +1661,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the entry must be set.", nameof(entryId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1686,7 +1684,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the content type must be set.", nameof(contentTypeId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1718,7 +1716,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the content type must be set.", nameof(contentTypeId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1736,7 +1734,7 @@ namespace Contentful.Core
         /// <returns>A collection of <see cref="Contentful.Core.Models.Management.SpaceMembership"/>.</returns>
         public async Task<ContentfulCollection<SpaceMembership>> GetSpaceMemberships(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1758,7 +1756,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<SpaceMembership> CreateSpaceMembership(SpaceMembership spaceMembership, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", ConvertObjectToJsonStringContent(spaceMembership), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", ConvertObjectToJsonStringContent(spaceMembership), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1783,7 +1781,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the space membership must be set", nameof(spaceMembershipId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembershipId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembershipId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1808,7 +1806,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the space membership id must be set", nameof(spaceMembership));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembership.SystemProperties.Id}",
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembership.SystemProperties.Id}",
                 ConvertObjectToJsonStringContent(spaceMembership), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -1833,7 +1831,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the space membership must be set", nameof(spaceMembershipId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembershipId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembershipId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -1847,7 +1845,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ApiKey>> GetAllApiKeys(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1868,7 +1866,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ApiKey>> GetAllPreviewApiKeys(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1890,7 +1888,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ApiKey> GetApiKey(string apiKeyId, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1909,7 +1907,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ApiKey> GetPreviewApiKey(string apiKeyId, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1934,7 +1932,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The name of the api key must be set.", nameof(name));
             }
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", ConvertObjectToJsonStringContent(new { name, description }), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", ConvertObjectToJsonStringContent(new { name, description }), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -1966,7 +1964,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the api key must be set.", nameof(id));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{id}", ConvertObjectToJsonStringContent(new { name, description }),
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{id}", ConvertObjectToJsonStringContent(new { name, description }),
                 cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -1985,7 +1983,7 @@ namespace Contentful.Core
         /// <returns>A <see cref="SystemProperties"/> with metadata of the upload.</returns>
         public async Task DeleteApiKey(string apiKeyId, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -1999,7 +1997,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<User>> GetAllUsers(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2027,7 +2025,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the user must be set", nameof(userId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users/{userId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users/{userId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2044,7 +2042,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<User> GetCurrentUser(CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_directApiUrl}users/me", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}users/me", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2062,7 +2060,7 @@ namespace Contentful.Core
         /// <returns>A <see cref="SystemProperties"/> with metadata of the upload.</returns>
         public async Task<UploadReference> GetUpload(string uploadId, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads/{uploadId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads/{uploadId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2083,7 +2081,7 @@ namespace Contentful.Core
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
 
-            var res = await PostAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads", byteArrayContent, cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads", byteArrayContent, cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2101,7 +2099,7 @@ namespace Contentful.Core
         /// <returns>A <see cref="SystemProperties"/> with metadata of the upload.</returns>
         public async Task DeleteUpload(string uploadId, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await DeleteAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads/{uploadId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads/{uploadId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -2147,7 +2145,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<UiExtension>> GetAllExtensions(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2172,7 +2170,7 @@ namespace Contentful.Core
             // The api does not accept a sys object in the extension creation.
             extension.SystemProperties = null;
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions",
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions",
                 ConvertObjectToJsonStringContent(extension), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -2203,7 +2201,7 @@ namespace Contentful.Core
             // The api does not accept a sys object in the extension creation.
             extension.SystemProperties = null;
 
-            var res = await PutAsync(
+            using var res = await PutAsync(
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{id}",
                 ConvertObjectToJsonStringContent(extension), cancellationToken, version).ConfigureAwait(false);
 
@@ -2230,7 +2228,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the extension must be set", nameof(extensionId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{extensionId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{extensionId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2254,7 +2252,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(extensionId));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{extensionId}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{extensionId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -2268,7 +2266,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ManagementToken> CreateManagementToken(ManagementToken token, CancellationToken cancellationToken = default)
         {
-            var res = await PostAsync($"{_directApiUrl}users/me/access_tokens",
+            using var res = await PostAsync($"{_directApiUrl}users/me/access_tokens",
                 ConvertObjectToJsonStringContent(new
                 {
                     name = token.Name,
@@ -2291,7 +2289,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ManagementToken>> GetAllManagementTokens(CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_directApiUrl}users/me/access_tokens", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}users/me/access_tokens", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2318,7 +2316,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the token must be set", nameof(managementTokenId));
             }
 
-            var res = await GetAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2342,7 +2340,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the token must be set", nameof(managementTokenId));
             }
 
-            var res = await PutAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}/revoked", null, cancellationToken, null).ConfigureAwait(false);
+            using var res = await PutAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}/revoked", null, cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2359,7 +2357,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<Organization>> GetOrganizations(CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_directApiUrl}organizations", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}organizations", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2380,7 +2378,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ContentfulEnvironment>> GetEnvironments(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2408,7 +2406,7 @@ namespace Contentful.Core
                 throw new ArgumentException("You must provide a name for the environment.", nameof(name));
             }
 
-            var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2440,7 +2438,7 @@ namespace Contentful.Core
                 throw new ArgumentException("You must provide a name for the environment.", nameof(name));
             }
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version: version).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version: version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2476,9 +2474,13 @@ namespace Contentful.Core
             {
                 throw new ArgumentException("You must provide an id for the source environment.", nameof(sourceEnvironmentId));
             }
-            var sourceHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-source-environment", new[] { sourceEnvironmentId });
 
-            var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null, additionalHeaders: new[] { sourceHeader }.ToList()).ConfigureAwait(false);
+            var sourceHeaders = new List<KeyValuePair<string, IEnumerable<string>>>(1)
+            {
+                new("x-contentful-source-environment", [sourceEnvironmentId])
+            };
+
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null, additionalHeaders: sourceHeaders).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2503,7 +2505,7 @@ namespace Contentful.Core
                 throw new ArgumentException("You must provide an id for the environment.", nameof(id));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2527,7 +2529,7 @@ namespace Contentful.Core
                 throw new ArgumentException("You must provide an id for the environment.", nameof(id));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", cancellationToken).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -2542,7 +2544,7 @@ namespace Contentful.Core
         public async Task<ContentfulCollection<UsagePeriod>> GetUsagePeriods(string organizationId, CancellationToken cancellationToken = default)
         {
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "usage-insights" });
-            var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usage_periods", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usage_periods", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2564,7 +2566,7 @@ namespace Contentful.Core
         public async Task<ContentfulCollection<OrganizationMembership>> GetOrganizationMemberships(string organizationId, string queryString = null, CancellationToken cancellationToken = default)
         {
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
-            var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2590,7 +2592,7 @@ namespace Contentful.Core
         {
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "usage-insights" });
 
-            var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usages/{type}{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usages/{type}{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
             var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
@@ -2615,7 +2617,7 @@ namespace Contentful.Core
         {
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
 
-            var res = await PostAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships", ConvertObjectToJsonStringContent(new { role, email, suppressInvitation }), cancellationToken, null, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await PostAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships", ConvertObjectToJsonStringContent(new { role, email, suppressInvitation }), cancellationToken, null, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
             var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
@@ -2642,7 +2644,7 @@ namespace Contentful.Core
             }
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
 
-            var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2668,7 +2670,7 @@ namespace Contentful.Core
             }
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
 
-            var res = await PutAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}",
+            using var res = await PutAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}",
                 ConvertObjectToJsonStringContent(new { role }), cancellationToken, null, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
@@ -2694,7 +2696,7 @@ namespace Contentful.Core
             }
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
 
-            var res = await DeleteAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -2709,7 +2711,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<ContentTag>> GetContentTagsCollection(string queryString = null, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags{queryString}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags{queryString}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res);
 
@@ -2737,7 +2739,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(contentTagId));
             }
 
-            var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{contentTagId}", cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{contentTagId}", cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2769,7 +2771,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the content tag must be set.", nameof(id));
             }
 
-            var res = await PutAsync(
+            using var res = await PutAsync(
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}",
                 ConvertObjectToJsonStringContent(new { name, sys = new { id, type = "tag", visibility = publiclyVisible ? "public" : "private" } }), cancellationToken, null).ConfigureAwait(false);
 
@@ -2803,7 +2805,7 @@ namespace Contentful.Core
                 throw new ArgumentException("The id of the content tag must be set.", nameof(id));
             }
 
-            var res = await PutAsync(
+            using var res = await PutAsync(
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}",
                 ConvertObjectToJsonStringContent(new { name, sys = new { id, type = "tag" } }), cancellationToken, version).ConfigureAwait(false);
 
@@ -2830,7 +2832,7 @@ namespace Contentful.Core
                 throw new ArgumentException(nameof(id));
             }
 
-            var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}", cancellationToken, version).ConfigureAwait(false);
+            using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}", cancellationToken, version).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
         }
@@ -2872,7 +2874,7 @@ namespace Contentful.Core
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
         public async Task<ContentfulCollection<T>> GetScheduledActions<T>(string nextOrPreviousPageLink, CancellationToken cancellationToken = default)
         {
-            var res = await GetAsync(nextOrPreviousPageLink, cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync(nextOrPreviousPageLink, cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -2923,7 +2925,7 @@ namespace Contentful.Core
         {
             var requestUrl = $"{_baseUrl}{spaceId ?? _options.SpaceId}/scheduled_actions/{scheduledActionId}?environment.sys.id={environmentId ?? _options.Environment}";
 
-            var res = await GetAsync(requestUrl, cancellationToken).ConfigureAwait(false);
+            using var res = await GetAsync(requestUrl, cancellationToken).ConfigureAwait(false);
 
             await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
@@ -3030,7 +3032,7 @@ namespace Contentful.Core
             return await SendHttpRequest(url, HttpMethod.Get, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
         }
 
-        private StringContent ConvertObjectToJsonStringContent(object ob)
+        private static StringContent ConvertObjectToJsonStringContent(object ob)
         {
             var serializedObject = ob.ConvertObjectToJsonString();
             return new StringContent(serializedObject, Encoding.UTF8, "application/vnd.contentful.management.v1+json");

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -74,11 +74,7 @@ namespace Contentful.Core
         {
             using var res = await PostAsync(_baseUrl, ConvertObjectToJsonStringContent(new { name, defaultLocale }), cancellationToken, null, organisationId: organisation).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<Space>(Serializer);
+            return await GetObjectFromResponse<Space>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -88,9 +84,9 @@ namespace Contentful.Core
         /// <param name="organisation">The organisation to update a space for. Not required if the account belongs to only one organisation.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The updated <see cref="Space"/></returns>
-        public async Task<Space> UpdateSpaceName(Space space, string organisation = null, CancellationToken cancellationToken = default)
+        public Task<Space> UpdateSpaceName(Space space, string organisation = null, CancellationToken cancellationToken = default)
         {
-            return await UpdateSpaceName(space.SystemProperties.Id, space.Name, space.SystemProperties.Version ?? 1, organisation, cancellationToken).ConfigureAwait(false);
+            return UpdateSpaceName(space.SystemProperties.Id, space.Name, space.SystemProperties.Version ?? 1, organisation, cancellationToken);
         }
 
         /// <summary>
@@ -106,11 +102,7 @@ namespace Contentful.Core
         {
             using var res = await PutAsync($"{_baseUrl}{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version, organisationId: organisation).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<Space>(Serializer);
+            return await GetObjectFromResponse<Space>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,11 +115,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{id}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<Space>(Serializer);
+            return await GetObjectFromResponse<Space>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -139,9 +127,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync(_baseUrl, cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var json = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             return json.SelectTokens("$..items[*]").Select(t => t.ToObject<Space>(Serializer));
         }
@@ -165,9 +151,9 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space to get the content types of. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
-        public async Task<IEnumerable<ContentType>> GetContentTypes(string spaceId = null, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<ContentType>> GetContentTypes(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            return await GetContentTypes(null, spaceId, cancellationToken);
+            return GetContentTypes(null, spaceId, cancellationToken);
         }
 
         /// <summary>
@@ -181,9 +167,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var json = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             return json.SelectTokens("$..items[*]").Select(t => t.ToObject<ContentType>(Serializer));
         }
@@ -217,11 +201,7 @@ namespace Contentful.Core
                 ConvertObjectToJsonStringContent(clone),
                 cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<ContentType>(Serializer);
+            return await GetObjectFromResponse<ContentType>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -242,12 +222,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var contentType = jsonObject.ToObject<ContentType>(Serializer);
-
-            return contentType;
+            return await GetObjectFromResponse<ContentType>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -290,12 +265,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var contentType = jsonObject.ToObject<ContentType>(Serializer);
-
-            return contentType;
+            return await GetObjectFromResponse<ContentType>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -325,9 +295,9 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space to get the activated content types of. Will default to the one set when creating the client.</param>
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ContentType"/>.</returns>
-        public async Task<IEnumerable<ContentType>> GetActivatedContentTypes(string spaceId = null, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<ContentType>> GetActivatedContentTypes(string spaceId = null, CancellationToken cancellationToken = default)
         {
-            return await GetActivatedContentTypes(null, spaceId, cancellationToken);
+            return GetActivatedContentTypes(null, spaceId, cancellationToken);
         }
 
         /// <summary>
@@ -341,9 +311,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/content_types/{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var json = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             return json.SelectTokens("$..items[*]").Select(t => t.ToObject<ContentType>(Serializer));
         }
@@ -366,12 +334,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var editorInterface = jsonObject.ToObject<EditorInterface>(Serializer);
-
-            return editorInterface;
+            return await GetObjectFromResponse<EditorInterface>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -397,12 +360,7 @@ namespace Contentful.Core
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/editor_interface",
                 ConvertObjectToJsonStringContent(editorInterface), cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var updatedEditorInterface = jsonObject.ToObject<EditorInterface>(Serializer);
-
-            return updatedEditorInterface;
+            return await GetObjectFromResponse<EditorInterface>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -458,9 +416,9 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of items.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<T>> GetEntriesCollection<T>(QueryBuilder<T> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
+        public Task<ContentfulCollection<T>> GetEntriesCollection<T>(QueryBuilder<T> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            return await GetEntriesCollection<T>(queryBuilder?.Build(), spaceId, cancellationToken).ConfigureAwait(false);
+            return GetEntriesCollection<T>(queryBuilder?.Build(), spaceId, cancellationToken);
         }
 
         /// <summary>
@@ -477,11 +435,9 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
             var isContentfulResource = typeof(IContentfulResource).GetTypeInfo().IsAssignableFrom(typeof(T).GetTypeInfo());
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             ReplaceMetaData(jsonObject);
 
@@ -531,12 +487,7 @@ namespace Contentful.Core
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries",
                 ConvertObjectToJsonStringContent(new { fields = entry.Fields, metadata = entry.Metadata }), cancellationToken, null, contentTypeId).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var updatedEntry = jsonObject.ToObject<Entry<dynamic>>(Serializer);
-
-            return updatedEntry;
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -577,12 +528,7 @@ namespace Contentful.Core
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entry.SystemProperties.Id}",
                 ConvertObjectToJsonStringContent(new { fields = entry.Fields, metadata = entry.Metadata }), cancellationToken, version, contentTypeId).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var updatedEntry = jsonObject.ToObject<Entry<dynamic>>(Serializer);
-
-            return updatedEntry;
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -707,9 +653,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             if (jObject.TryGetValue("metadata", out var val))
             {
@@ -759,9 +703,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            return JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false)).ToObject<Entry<dynamic>>(Serializer);
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -783,9 +725,7 @@ namespace Contentful.Core
 
             using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            return JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false)).ToObject<Entry<dynamic>>(Serializer);
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -807,9 +747,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", null, cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            return JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false)).ToObject<Entry<dynamic>>(Serializer);
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -831,9 +769,7 @@ namespace Contentful.Core
 
             using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/archived", cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            return JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false)).ToObject<Entry<dynamic>>(Serializer);
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -844,9 +780,9 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of <see cref="Contentful.Core.Models.Management.ManagementAsset"/>.</returns>
         /// <exception cref="Contentful.Core.Errors.ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<ManagementAsset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
+        public Task<ContentfulCollection<ManagementAsset>> GetAssetsCollection(QueryBuilder<ManagementAsset> queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            return await GetAssetsCollection(queryBuilder?.Build(), spaceId, cancellationToken).ConfigureAwait(false);
+            return GetAssetsCollection(queryBuilder?.Build(), spaceId, cancellationToken);
         }
 
         /// <summary>
@@ -861,9 +797,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ManagementAsset>>(Serializer);
             var assets = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ManagementAsset>(Serializer));
             collection.Items = assets;
@@ -882,9 +816,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}public/assets", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ManagementAsset>>(Serializer);
             var assets = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ManagementAsset>(Serializer));
             collection.Items = assets;
@@ -910,11 +842,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementAsset>(Serializer);
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -957,11 +885,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", null, cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementAsset>(Serializer);
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -983,11 +907,7 @@ namespace Contentful.Core
 
             using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/published", cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementAsset>(Serializer);
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1011,11 +931,7 @@ namespace Contentful.Core
 
             res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/archived", null, cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementAsset>(Serializer);
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1037,11 +953,7 @@ namespace Contentful.Core
 
             using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets/{assetId}/archived", cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementAsset>(Serializer);
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1132,12 +1044,7 @@ namespace Contentful.Core
                 }
                 ), cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var updatedAsset = jsonObject.ToObject<ManagementAsset>(Serializer);
-
-            return updatedAsset;
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1153,12 +1060,7 @@ namespace Contentful.Core
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}assets",
                 ConvertObjectToJsonStringContent(new { fields = new { title = asset.Title, description = asset.Description, file = asset.Files } }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var createdAsset = jsonObject.ToObject<ManagementAsset>(Serializer);
-
-            return createdAsset;
+            return await GetObjectFromResponse<ManagementAsset>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1172,9 +1074,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);;
             var collection = jsonObject.ToObject<ContentfulCollection<Locale>>(Serializer);
             var locales = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<Locale>(Serializer));
             collection.Items = locales;
@@ -1204,11 +1104,7 @@ namespace Contentful.Core
                         optional = locale.Optional
                     }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Locale>(Serializer);
+            return await GetObjectFromResponse<Locale>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1229,11 +1125,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}locales/{localeId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Locale>(Serializer);
+            return await GetObjectFromResponse<Locale>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1261,11 +1153,7 @@ namespace Contentful.Core
                 optional = locale.Optional
             }), cancellationToken, locale.SystemProperties.Version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Locale>(Serializer);
+            return await GetObjectFromResponse<Locale>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1300,9 +1188,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<Webhook>>(Serializer);
             var hooks = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<Webhook>(Serializer));
             collection.Items = hooks;
@@ -1325,11 +1211,7 @@ namespace Contentful.Core
 
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions", ConvertObjectToJsonStringContent(webhook), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Webhook>(Serializer);
+            return await GetObjectFromResponse<Webhook>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1356,11 +1238,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{id}", ConvertObjectToJsonStringContent(webhook), cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Webhook>(Serializer);
+            return await GetObjectFromResponse<Webhook>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1381,11 +1259,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhook_definitions/{webhookId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Webhook>(Serializer);
+            return await GetObjectFromResponse<Webhook>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1426,9 +1300,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<WebhookCallDetails>>(Serializer);
             var hooks = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<WebhookCallDetails>(Serializer));
             collection.Items = hooks;
@@ -1460,11 +1332,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/calls/{callId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<WebhookCallDetails>(Serializer);
+            return await GetObjectFromResponse<WebhookCallDetails>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1485,9 +1353,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/webhooks/{webhookId}/health", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var health = new WebhookHealthResponse()
             {
                 SystemProperties = jsonObject["sys"]?.ToObject<SystemProperties>(Serializer),
@@ -1515,11 +1381,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{roleId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Role>(Serializer);
+            return await GetObjectFromResponse<Role>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1533,9 +1395,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<Role>>(Serializer);
             var roles = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<Role>(Serializer));
             collection.Items = roles;
@@ -1558,11 +1418,7 @@ namespace Contentful.Core
 
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Role>(Serializer);
+            return await GetObjectFromResponse<Role>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1588,11 +1444,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{id}", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Role>(Serializer);
+            return await GetObjectFromResponse<Role>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1631,9 +1483,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<Snapshot>>(Serializer);
             var snapshots = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<Snapshot>(Serializer));
             collection.Items = snapshots;
@@ -1663,11 +1513,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<Snapshot>(Serializer);
+            return await GetObjectFromResponse<Snapshot>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1686,9 +1532,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<SnapshotContentType>>(Serializer);
             var snapshots = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<SnapshotContentType>(Serializer));
             collection.Items = snapshots;
@@ -1718,11 +1562,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}content_types/{contentTypeId}/snapshots/{snapshotId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<SnapshotContentType>(Serializer);
+            return await GetObjectFromResponse<SnapshotContentType>(res).ConfigureAwait(false);
         }
 
 
@@ -1736,9 +1576,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<SpaceMembership>>(Serializer);
             var memberships = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<SpaceMembership>(Serializer));
             collection.Items = memberships;
@@ -1758,11 +1596,7 @@ namespace Contentful.Core
         {
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships", ConvertObjectToJsonStringContent(spaceMembership), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<SpaceMembership>(Serializer);
+            return await GetObjectFromResponse<SpaceMembership>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1783,11 +1617,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembershipId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<SpaceMembership>(Serializer);
+            return await GetObjectFromResponse<SpaceMembership>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1809,11 +1639,7 @@ namespace Contentful.Core
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/space_memberships/{spaceMembership.SystemProperties.Id}",
                 ConvertObjectToJsonStringContent(spaceMembership), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<SpaceMembership>(Serializer);
+            return await GetObjectFromResponse<SpaceMembership>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1847,9 +1673,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ApiKey>>(Serializer);
             var keys = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ApiKey>(Serializer));
             collection.Items = keys;
@@ -1868,9 +1692,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ApiKey>>(Serializer);
             var keys = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ApiKey>(Serializer));
             collection.Items = keys;
@@ -1890,11 +1712,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ApiKey>(Serializer);
+            return await GetObjectFromResponse<ApiKey>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1909,11 +1727,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/preview_api_keys/{apiKeyId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ApiKey>(Serializer);
+            return await GetObjectFromResponse<ApiKey>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1934,11 +1748,7 @@ namespace Contentful.Core
 
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys", ConvertObjectToJsonStringContent(new { name, description }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ApiKey>(Serializer);
+            return await GetObjectFromResponse<ApiKey>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1967,11 +1777,7 @@ namespace Contentful.Core
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/api_keys/{id}", ConvertObjectToJsonStringContent(new { name, description }),
                 cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ApiKey>(Serializer);
+            return await GetObjectFromResponse<ApiKey>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1999,9 +1805,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<User>>(Serializer);
             var keys = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<User>(Serializer));
             collection.Items = keys;
@@ -2027,11 +1831,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/users/{userId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<User>(Serializer);
+            return await GetObjectFromResponse<User>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2044,11 +1844,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_directApiUrl}users/me", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<User>(Serializer);
+            return await GetObjectFromResponse<User>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2062,11 +1858,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads/{uploadId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<UploadReference>(Serializer);
+            return await GetObjectFromResponse<UploadReference>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2083,11 +1875,7 @@ namespace Contentful.Core
 
             using var res = await PostAsync($"{_baseUploadUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}uploads", byteArrayContent, cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<UploadReference>(Serializer);
+            return await GetObjectFromResponse<UploadReference>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2147,9 +1935,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<UiExtension>>(Serializer);
             var keys = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<UiExtension>(Serializer));
             collection.Items = keys;
@@ -2173,11 +1959,7 @@ namespace Contentful.Core
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions",
                 ConvertObjectToJsonStringContent(extension), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<UiExtension>(Serializer);
+            return await GetObjectFromResponse<UiExtension>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2205,11 +1987,7 @@ namespace Contentful.Core
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{id}",
                 ConvertObjectToJsonStringContent(extension), cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<UiExtension>(Serializer);
+            return await GetObjectFromResponse<UiExtension>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2230,11 +2008,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}extensions/{extensionId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<UiExtension>(Serializer);
+            return await GetObjectFromResponse<UiExtension>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2273,11 +2047,7 @@ namespace Contentful.Core
                     scopes = token.Scopes
                 }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementToken>(Serializer);
+            return await GetObjectFromResponse<ManagementToken>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2291,9 +2061,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_directApiUrl}users/me/access_tokens", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ManagementToken>>(Serializer);
             var keys = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ManagementToken>(Serializer));
             collection.Items = keys;
@@ -2318,11 +2086,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementToken>(Serializer);
+            return await GetObjectFromResponse<ManagementToken>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2342,11 +2106,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_directApiUrl}users/me/access_tokens/{managementTokenId}/revoked", null, cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ManagementToken>(Serializer);
+            return await GetObjectFromResponse<ManagementToken>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2359,9 +2119,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_directApiUrl}organizations", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<Organization>>(Serializer);
             var orgs = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<Organization>(Serializer));
             collection.Items = orgs;
@@ -2380,9 +2138,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ContentfulEnvironment>>(Serializer);
             var environments = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ContentfulEnvironment>(Serializer));
             collection.Items = environments;
@@ -2408,11 +2164,7 @@ namespace Contentful.Core
 
             using var res = await PostAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ContentfulEnvironment>(Serializer);
+            return await GetObjectFromResponse<ContentfulEnvironment>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2440,11 +2192,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, version: version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ContentfulEnvironment>(Serializer);
+            return await GetObjectFromResponse<ContentfulEnvironment>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2482,11 +2230,7 @@ namespace Contentful.Core
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null, additionalHeaders: sourceHeaders).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ContentfulEnvironment>(Serializer);
+            return await GetObjectFromResponse<ContentfulEnvironment>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2507,11 +2251,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ContentfulEnvironment>(Serializer);
+            return await GetObjectFromResponse<ContentfulEnvironment>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2546,9 +2286,7 @@ namespace Contentful.Core
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "usage-insights" });
             using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usage_periods", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             var collection = jsonObject.ToObject<ContentfulCollection<UsagePeriod>>(Serializer);
             var periods = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<UsagePeriod>(Serializer));
@@ -2568,9 +2306,7 @@ namespace Contentful.Core
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
             using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             var collection = jsonObject.ToObject<ContentfulCollection<OrganizationMembership>>(Serializer);
             var memberships = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<OrganizationMembership>(Serializer));
@@ -2593,9 +2329,8 @@ namespace Contentful.Core
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "usage-insights" });
 
             using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/usages/{type}{queryString}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ApiUsage>>(Serializer);
             var apiUsage = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ApiUsage>(Serializer));
             collection.Items = apiUsage;
@@ -2618,9 +2353,8 @@ namespace Contentful.Core
             var alphaHeader = new KeyValuePair<string, IEnumerable<string>>("x-contentful-enable-alpha-feature", new[] { "organization-user-management-api" });
 
             using var res = await PostAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships", ConvertObjectToJsonStringContent(new { role, email, suppressInvitation }), cancellationToken, null, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
 
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ApiUsage>>(Serializer);
             var apiUsage = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ApiUsage>(Serializer));
             collection.Items = apiUsage;
@@ -2646,11 +2380,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}", cancellationToken, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<OrganizationMembership>(Serializer);
+            return await GetObjectFromResponse<OrganizationMembership>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2673,11 +2403,7 @@ namespace Contentful.Core
             using var res = await PutAsync($"{_directApiUrl}organizations/{organizationId}/organization_memberships/{membershipId}",
                 ConvertObjectToJsonStringContent(new { role }), cancellationToken, null, additionalHeaders: new[] { alphaHeader }.ToList()).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<OrganizationMembership>(Serializer);
+            return await GetObjectFromResponse<OrganizationMembership>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2713,9 +2439,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags{queryString}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
             var collection = jsonObject.ToObject<ContentfulCollection<ContentTag>>(Serializer);
             var tags = jsonObject.SelectTokens("$..items[*]").Select(c => c.ToObject<ContentTag>(Serializer));
             collection.Items = tags;
@@ -2741,11 +2465,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{contentTagId}", cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return jsonObject.ToObject<ContentTag>(Serializer);
+            return await GetObjectFromResponse<ContentTag>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2775,11 +2495,7 @@ namespace Contentful.Core
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}",
                 ConvertObjectToJsonStringContent(new { name, sys = new { id, type = "tag", visibility = publiclyVisible ? "public" : "private" } }), cancellationToken, null).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<ContentTag>(Serializer);
+            return await GetObjectFromResponse<ContentTag>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2809,11 +2525,7 @@ namespace Contentful.Core
                 $"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}tags/{id}",
                 ConvertObjectToJsonStringContent(new { name, sys = new { id, type = "tag" } }), cancellationToken, version).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var json = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-
-            return json.ToObject<ContentTag>(Serializer);
+            return await GetObjectFromResponse<ContentTag>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2846,9 +2558,9 @@ namespace Contentful.Core
         /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
         /// <returns>A <see cref="ContentfulCollection{T}"/> of items.</returns>
         /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
-        public async Task<ContentfulCollection<T>> GetScheduledActions<T>(ScheduledActionQueryBuilder queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
+        public Task<ContentfulCollection<T>> GetScheduledActions<T>(ScheduledActionQueryBuilder queryBuilder, string spaceId = null, CancellationToken cancellationToken = default)
         {
-            return await GetScheduledActions<T>(queryBuilder?.Build(), spaceId, cancellationToken).ConfigureAwait(false);
+            return GetScheduledActions<T>(queryBuilder?.Build(), spaceId, cancellationToken);
         }
 
         public async Task<ContentfulCollection<T>> GetScheduledActions<T>(string queryString = null, string spaceId = null, CancellationToken cancellationToken = default)
@@ -2876,9 +2588,7 @@ namespace Contentful.Core
         {
             using var res = await GetAsync(nextOrPreviousPageLink, cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jsonObject = await GetJObjectFromResponse(res).ConfigureAwait(false);
 
             ReplaceMetaData(jsonObject);
 
@@ -2896,9 +2606,9 @@ namespace Contentful.Core
         /// <typeparam name="T"></typeparam>
         /// <param name="scheduledActionId">Id of the scheduled action</param>
         /// <returns></returns>
-        public async Task<T> GetScheduledAction<T>(string scheduledActionId, CancellationToken cancellationToken = default)
+        public Task<T> GetScheduledAction<T>(string scheduledActionId, CancellationToken cancellationToken = default)
         {
-            return await GetScheduledAction<T>(scheduledActionId, _options.Environment, _options.SpaceId, cancellationToken).ConfigureAwait(false); ;
+            return GetScheduledAction<T>(scheduledActionId, _options.Environment, _options.SpaceId, cancellationToken);
         }
 
         /// <summary>
@@ -2908,9 +2618,9 @@ namespace Contentful.Core
         /// <param name="scheduledActionId">Id of the scheduled action</param>
         /// <param name="environmentId">Specify environment</param>
         /// <returns></returns>
-        public async Task<T> GetScheduledAction<T>(string scheduledActionId, string environmentId, CancellationToken cancellationToken = default)
+        public Task<T> GetScheduledAction<T>(string scheduledActionId, string environmentId, CancellationToken cancellationToken = default)
         {
-            return await GetScheduledAction<T>(scheduledActionId, environmentId, _options.SpaceId, cancellationToken).ConfigureAwait(false); ;
+            return GetScheduledAction<T>(scheduledActionId, environmentId, _options.SpaceId, cancellationToken);
         }
 
         /// <summary>
@@ -2927,12 +2637,7 @@ namespace Contentful.Core
 
             using var res = await GetAsync(requestUrl, cancellationToken).ConfigureAwait(false);
 
-            await EnsureSuccessfulResult(res).ConfigureAwait(false);
-
-            var jsonObject = JObject.Parse(await res.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var scheduledAction = jsonObject.ToObject<T>(Serializer);
-
-            return scheduledAction;
+            return await GetObjectFromResponse<T>(res).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2949,10 +2654,7 @@ namespace Contentful.Core
 
             var result = await PostAsync(requestUrl, ConvertObjectToJsonStringContent(GetScheduledActionRequestObject(scheduledAction)), cancellationToken, 0);
 
-            await EnsureSuccessfulResult(result).ConfigureAwait(false);
-
-            var json = JObject.Parse(await result.Content.ReadAsStringAsync().ConfigureAwait(false));
-            return json.ToObject<ScheduledAction>(Serializer);
+            return await GetObjectFromResponse<ScheduledAction>(result).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2972,10 +2674,7 @@ namespace Contentful.Core
 
             var result = await PutAsync(requestUrl, ConvertObjectToJsonStringContent(GetScheduledActionRequestObject(scheduledAction)), cancellationToken, scheduledAction.SystemProperties.Version);
 
-            await EnsureSuccessfulResult(result).ConfigureAwait(false);
-
-            var json = JObject.Parse(await result.Content.ReadAsStringAsync().ConfigureAwait(false));
-            return json.ToObject<ScheduledAction>(Serializer);
+            return await GetObjectFromResponse<ScheduledAction>(result).ConfigureAwait(false);
         }
 
         private object GetScheduledActionRequestObject(ScheduledAction scheduledAction)
@@ -3006,30 +2705,27 @@ namespace Contentful.Core
 
             var result = await DeleteAsync(requestUrl, cancellationToken);
 
-            await EnsureSuccessfulResult(result).ConfigureAwait(false);
-
-            var json = JObject.Parse(await result.Content.ReadAsStringAsync().ConfigureAwait(false));
-            return json.ToObject<ScheduledAction>(Serializer);
+            return await GetObjectFromResponse<ScheduledAction>(result).ConfigureAwait(false);
         }
 
-        private async Task<HttpResponseMessage> PostAsync(string url, HttpContent content, CancellationToken cancellationToken, int? version, string contentTypeId = null, string organisationId = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private Task<HttpResponseMessage> PostAsync(string url, HttpContent content, CancellationToken cancellationToken, int? version, string contentTypeId = null, string organisationId = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
-            return await SendHttpRequest(url, HttpMethod.Post, _options.ManagementApiKey, cancellationToken, content, version, contentTypeId, organisationId, additionalHeaders: additionalHeaders).ConfigureAwait(false);
+            return SendHttpRequest(url, HttpMethod.Post, _options.ManagementApiKey, cancellationToken, content, version, contentTypeId, organisationId, additionalHeaders: additionalHeaders);
         }
 
-        private async Task<HttpResponseMessage> PutAsync(string url, HttpContent content, CancellationToken cancellationToken, int? version, string contentTypeId = null, string organisationId = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private Task<HttpResponseMessage> PutAsync(string url, HttpContent content, CancellationToken cancellationToken, int? version, string contentTypeId = null, string organisationId = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
-            return await SendHttpRequest(url, HttpMethod.Put, _options.ManagementApiKey, cancellationToken, content, version, contentTypeId, organisationId, additionalHeaders: additionalHeaders).ConfigureAwait(false);
+            return SendHttpRequest(url, HttpMethod.Put, _options.ManagementApiKey, cancellationToken, content, version, contentTypeId, organisationId, additionalHeaders: additionalHeaders);
         }
 
-        private async Task<HttpResponseMessage> DeleteAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private Task<HttpResponseMessage> DeleteAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
-            return await SendHttpRequest(url, HttpMethod.Delete, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
+            return SendHttpRequest(url, HttpMethod.Delete, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders);
         }
 
-        private async Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
+        private Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken, int? version = null, List<KeyValuePair<string, IEnumerable<string>>> additionalHeaders = null)
         {
-            return await SendHttpRequest(url, HttpMethod.Get, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders).ConfigureAwait(false);
+            return SendHttpRequest(url, HttpMethod.Get, _options.ManagementApiKey, cancellationToken, version: version, additionalHeaders: additionalHeaders);
         }
 
         private static StringContent ConvertObjectToJsonStringContent(object ob)

--- a/Contentful.Core/Extensions/JsonConversionExtensions.cs
+++ b/Contentful.Core/Extensions/JsonConversionExtensions.cs
@@ -1,5 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Contentful.Core.Configuration;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Contentful.Core.Extensions
@@ -9,24 +15,58 @@ namespace Contentful.Core.Extensions
     /// </summary>
     public static class JsonConversionExtensions
     {
+        /// <summary>Deserializes an object of type T from the response</summary>
+        /// <param name="response">The response to deserialize from</param>
+        /// <param name="serializer">The serializer to use</param>
+        /// <typeparam name="T">The type to deserialize into</typeparam>
+        /// <returns>The deserialized object</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the response is null</exception>
+        /// <exception cref="ArgumentException">Thrown if response.Content is null</exception>
+        public static async Task<T> GetObjectFromResponse<T>(this HttpResponseMessage response, JsonSerializer serializer)
+        {
+            if (response == null) throw new ArgumentNullException(nameof(response));
+            if (response.Content == null)
+                throw new ArgumentException(nameof(response.Content) + " is null", nameof(response));
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var streamReader = new StreamReader(stream);
+            using var jsonReader = new JsonTextReader(streamReader);
+            return serializer.Deserialize<T>(jsonReader);
+        }
+
+        /// <summary>Deserializes a JObject from the response</summary>
+        /// <param name="response">The response to deserialize from</param>
+        /// <returns>The deserialized JObject</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the response is null</exception>
+        /// <exception cref="ArgumentException">Thrown if response.Content is null</exception>
+        public static async Task<JObject> GetJObjectFromResponse(this HttpResponseMessage response)
+        {
+            if (response == null) throw new ArgumentNullException(nameof(response));
+            if (response.Content == null)
+                throw new ArgumentException(nameof(response.Content) + " is null", nameof(response));
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var streamReader = new StreamReader(stream);
+            using var jsonReader = new JsonTextReader(streamReader);
+            return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+        }
+
+        private static readonly JsonSerializerSettings SerializerSettings = new()
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver
+            {
+                NamingStrategy =
+                {
+                    OverrideSpecifiedNames = false
+                }
+            },
+            Converters = new List<JsonConverter>
+            {
+                new ExtensionJsonConverter(),
+            },
+        };
+
         /// <summary>
         /// Converts the object to Json to use when sending a parameter in the body of a request to the Contentful API.
         /// </summary>
-        public static string ConvertObjectToJsonString(this object ob)
-        {
-            var resolver = new CamelCasePropertyNamesContractResolver();
-            resolver.NamingStrategy.OverrideSpecifiedNames = false;
-
-            var settings = new JsonSerializerSettings
-            {
-                ContractResolver = resolver,
-            };
-
-            settings.Converters.Add(new ExtensionJsonConverter());
-
-            var serializedObject = JsonConvert.SerializeObject(ob, settings);
-
-            return serializedObject;
-        }
+        public static string ConvertObjectToJsonString(this object ob) => JsonConvert.SerializeObject(ob, SerializerSettings);
     }
 }

--- a/Contentful.Core/Models/Management/IFieldValidation.cs
+++ b/Contentful.Core/Models/Management/IFieldValidation.cs
@@ -3,7 +3,6 @@ using Contentful.Core.Search;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 
 namespace Contentful.Core.Models.Management
@@ -466,7 +465,7 @@ namespace Contentful.Core.Models.Management
     /// </summary>  
     public class DateRangeValidator : IFieldValidator
     {
-        private string _min;
+        private readonly string _min;
 
         /// <summary>
         /// The minimum allowed date.
@@ -482,7 +481,7 @@ namespace Contentful.Core.Models.Management
             }
         }
 
-        private string _max;
+        private readonly string _max;
 
         /// <summary>
         /// The maximum allowed date.
@@ -573,7 +572,7 @@ namespace Contentful.Core.Models.Management
         }
 
 
-        private int? GetCalculatedByteSize(int? value, string unit)
+        private static int? GetCalculatedByteSize(int? value, string unit)
         {
             if (value != null)
             {
@@ -675,7 +674,7 @@ namespace Contentful.Core.Models.Management
         }
     }
 
-    internal class Nodes
+    internal sealed class Nodes
     {
         public Nodes(NodesValidator validator)
         {

--- a/Contentful.Core/Search/SelectVisitor.cs
+++ b/Contentful.Core/Search/SelectVisitor.cs
@@ -1,14 +1,12 @@
 ﻿using Contentful.Core.Models;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Contentful.Core.Search
 {
-    internal class SelectVisitor : ExpressionVisitor
+    internal sealed class SelectVisitor : ExpressionVisitor
     {
         private readonly Type _sourceType;
         private readonly string _prefix;


### PR DESCRIPTION
- Avoid waiting for a complete response before checking the success status code 
Status code can be checked when the first response package arrives
- Avoid deserializing into a string by deserializing directly from the response stream.  
Then deserialization can start immediately, instead of waiting for the entire response.  
The previously allocated string would have been the double size of the response, as the string is UTF-16 & the response UTF-8
- Use HTTP/2
- Use HTTP response compression by default, configurable to disabled when hosting in same datacenter as contentful
- Avoid evaluating OS & Version for every request
- Reuse JsonSerializerSettings
- Avoid async Task methods where it adds no value
- Avoid a possible MemoryStream leak
- Other minor tweaks