### PR TITLE
fix: respect baseUrl for ContentfulManagementClient

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -42,6 +42,8 @@ namespace Contentful.Core
                 throw new ArgumentException("The ContentfulOptions cannot be null.", nameof(options));
             }
 
+            _baseUrl = options.BaseUrl;
+
             SerializerSettings.Converters.Add(new ExtensionJsonConverter());
             SerializerSettings.Converters.Add(new ContentJsonConverter());
         }


### PR DESCRIPTION
Currently ContentfulManagementClient is not respecting the BaseUrl in the options passed. This PR fixes it.