### PR TITLE
Locale based publishing implemented in the c# sdk

### DIFF
--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Contentful.Core
 {
@@ -726,6 +727,90 @@ namespace Contentful.Core
             }
 
             using var res = await DeleteAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", cancellationToken, version).ConfigureAwait(false);
+
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Publishes an entry with locale-based publishing by the specified id.
+        /// This method adds support for publishing specific locales
+        /// </summary>
+        /// <param name="entryId">The id of the entry.</param>
+        /// <param name="version">The last known version of the entry.</param>
+        /// <param name="locales">The list of locale codes to be published.</param>
+        /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
+        /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
+        /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
+        /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="entryId"/> parameter was null or empty.</exception>
+        public async Task<Entry<dynamic>> PublishEntryLocales(string entryId, int version, string[] locales, string spaceId = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(entryId))
+            {
+                throw new ArgumentException(nameof(entryId));
+            }
+            if (locales == null || locales.Length == 0)
+            {
+                throw new ArgumentException("Locales array cannot be null or empty.", nameof(locales));
+            }
+
+            var payload = new
+            {
+                add = new
+                {
+                    fields = new Dictionary<string, IEnumerable<string>>
+                    {
+                        { "*", locales }
+                    }
+                }
+            };
+
+            var jsonPayload = JsonConvert.SerializeObject(payload);
+            var content = new StringContent(jsonPayload, Encoding.UTF8, "application/vnd.contentful.management.v1+json");
+
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", content, cancellationToken, version).ConfigureAwait(false);
+
+            return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// UnPublishes an entry with locale-based publishing by the specified id.
+        /// This method adds support for publishing specific locales
+        /// </summary>
+        /// <param name="entryId">The id of the entry.</param>
+        /// <param name="version">The last known version of the entry.</param>
+        /// <param name="locales">The list of locale codes to be Unpublished.</param>
+        /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
+        /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
+        /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
+        /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="entryId"/> parameter was null or empty.</exception>
+        public async Task<Entry<dynamic>> UnPublishEntryLocales(string entryId, int version, string[] locales, string spaceId = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(entryId))
+            {
+                throw new ArgumentException(nameof(entryId));
+            }
+            if (locales == null || locales.Length == 0)
+            {
+                throw new ArgumentException("Locales array cannot be null or empty.", nameof(locales));
+            }
+
+            var payload = new
+            {
+                remove = new
+                {
+                    fields = new Dictionary<string, IEnumerable<string>>
+                    {
+                        { "*", locales }
+                    }
+                }
+            };
+
+            var jsonPayload = JsonConvert.SerializeObject(payload);
+            var content = new StringContent(jsonPayload, Encoding.UTF8, "application/vnd.contentful.management.v1+json");
+
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/{EnvironmentsBase}entries/{entryId}/published", content, cancellationToken, version).ConfigureAwait(false);
 
             return await GetObjectFromResponse<Entry<dynamic>>(res).ConfigureAwait(false);
         }

--- a/Contentful.Core/IContentfulManagementClient.cs
+++ b/Contentful.Core/IContentfulManagementClient.cs
@@ -666,6 +666,18 @@ namespace Contentful.Core
         Task<Entry<dynamic>> PublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Publishes an entry with locale-based publishing by the specified id.
+        /// This method adds support for publishing specific locales
+        /// </summary>
+        /// <param name="entryId">The id of the entry.</param>
+        /// <param name="version">The last known version of the entry.</param>
+        /// <param name="locales">The list of locale codes to be published.</param>
+        /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
+        /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
+        /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
+        Task<Entry<dynamic>> PublishEntryLocales(string entryId, int version, string[] locales, string spaceId = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Unarchives an asset by the specified id.
         /// </summary>
         /// <param name="assetId">The id of the asset to unarchive.</param>
@@ -704,6 +716,20 @@ namespace Contentful.Core
         /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
         /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
         Task<Entry<dynamic>> UnpublishEntry(string entryId, int version, string spaceId = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// UnPublishes an entry with locale-based publishing by the specified id.
+        /// This method adds support for publishing specific locales
+        /// </summary>
+        /// <param name="entryId">The id of the entry.</param>
+        /// <param name="version">The last known version of the entry.</param>
+        /// <param name="locales">The list of locale codes to be Unpublished.</param>
+        /// <param name="spaceId">The id of the space. Will default to the one set when creating the client.</param>
+        /// <param name="cancellationToken">The optional cancellation token to cancel the operation.</param>
+        /// <returns>The response from the API serialized into <see cref="Entry{dynamic}"/></returns>
+        /// <exception cref="ContentfulException">There was an error when communicating with the Contentful API.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="entryId"/> parameter was null or empty.</exception>
+        Task<Entry<dynamic>> UnPublishEntryLocales(string entryId, int version, string[] locales, string spaceId = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a <see cref="Contentful.Core.Models.Management.EditorInterface"/> for a specific <see cref="ContentType"/>.

--- a/Contentful.Core/Models/FieldStatus.cs
+++ b/Contentful.Core/Models/FieldStatus.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Contentful.Core.Models;
+
+public class FieldStatus
+{
+    [JsonProperty(PropertyName = "*")]
+    public Dictionary<string, FieldStatusType> Status { get; set; }
+}
+
+public enum FieldStatusType
+{
+    [JsonProperty(PropertyName = "changed")]
+    Changed,
+    [JsonProperty(PropertyName = "draft")]
+    Draft,    
+    [JsonProperty(PropertyName = "published")]
+    Published,
+    [JsonProperty(PropertyName = "deleted")]
+    Deleted,
+}

--- a/Contentful.Core/Models/SystemProperties.cs
+++ b/Contentful.Core/Models/SystemProperties.cs
@@ -90,7 +90,10 @@ namespace Contentful.Core.Models
         /// The link to the status that the current object had. Used only for resources that have a status.
         /// </summary>
         public Status Status { get; set; }
+
+        /// <summary>
+        /// The link to the field status that the current object has. Used to get locale based publishing status.
+        /// </summary>
+        public FieldStatus FieldStatus { get; set; }
     }
 }
-
-


### PR DESCRIPTION
Added PublishEntryLocales and UnPublishEntryLocales to allow for sending a list of locales to publish or unpublish from the sdk. this is needed when localebased publishing is enabled on the contentful environment.

Added FieldStatus to the systemProperties, to match the field properties returned from the api, telling the status of each locale comming from contentful