### PR TITLE
fix: update CircleCI config and fix syntax error to make build pass []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: microsoft/aspnetcore-build:2.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: cimg/dotnet:7.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/dotnet:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
-version: 2.1
+version: 2
 jobs:
   build:
     docker:
-      - image: cimg/dotnet:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
     steps:
+      - run: apt-get update && apt-get install -y ssh git
       - checkout
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: microsoft/aspnetcore-build:2.0
+      - image: cimg/dotnet:8.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ jobs:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
+      - run:
+          name: Install git + ssh
+          command: |
+            apt-get update
+            apt-get install -y git openssh-client
       - checkout
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,9 @@
-version: 2.1
+version: 2
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: microsoft/aspnetcore-build:2.0
     steps:
-      - run:
-          name: Install git + ssh
-          command: |
-            apt-get update
-            apt-get install -y git openssh-client
       - checkout
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - run: apt-get update && apt-get install -y ssh git
       - checkout

--- a/Contentful.AspNetCore/Contentful.AspNetCore.csproj
+++ b/Contentful.AspNetCore/Contentful.AspNetCore.csproj
@@ -3,7 +3,7 @@
     <Description>Official .NET SDK for the Contentful Content Delivery and Management API for ASP.NET core.</Description>
     <PackageId>contentful.aspnetcore</PackageId>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>8.3.0</VersionPrefix>
+    <VersionPrefix>8.3.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Contentful</Authors>
     <Copyright>Contentful GmbH.</Copyright>
@@ -13,10 +13,10 @@
     <PackageProjectUrl>https://github.com/contentful/contentful.net</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <Version>8.3.0</Version>
-    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <Version>8.3.1</Version>
+    <AssemblyVersion>8.3.1.0</AssemblyVersion>
     <RepositoryUrl>https://github.com/contentful/contentful.net</RepositoryUrl>
-    <FileVersion>8.3.0.0</FileVersion>
+    <FileVersion>8.3.1.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.5\Contentful.AspNetCore.xml</DocumentationFile>
@@ -25,7 +25,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="contentful.csharp" Version="8.3.0" />
+    <PackageReference Include="contentful.csharp" Version="8.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />

--- a/Contentful.Core/Contentful.Core.csproj
+++ b/Contentful.Core/Contentful.Core.csproj
@@ -4,7 +4,7 @@
     <PackageId>contentful.csharp</PackageId>
     <AssemblyTitle>contentful.net</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>8.3.0</VersionPrefix>
+    <VersionPrefix>8.3.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Contentful</Authors>
     <Copyright>Contentful GmbH.</Copyright>

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -2227,7 +2227,7 @@ namespace Contentful.Core
 
             var sourceHeaders = new List<KeyValuePair<string, IEnumerable<string>>>(1)
             {
-                new("x-contentful-source-environment", [sourceEnvironmentId])
+                new("x-contentful-source-environment", new[] { sourceEnvironmentId })
             };
 
             using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/environments/{id}", ConvertObjectToJsonStringContent(new { name }), cancellationToken, null, additionalHeaders: sourceHeaders).ConfigureAwait(false);


### PR DESCRIPTION
This PR updates the Docker image used in the CircleCI pipeline, since the original `microsoft/aspnetcore-build:2.0` image is deprecated. The new image needs `ssh` and `git` to be installed, so this is added to the steps. Finally, a syntax error was fixed because the build was failing with an error `Invalid expression term '['`, so I changed the syntax to be valid in all modern C# versions.