### PR TITLE
fix: Add version header to UpdateRole method to fix ContentfulException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,31 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version [8.4.1]
+
+- Add version header to UpdateRole method to fix ContentfulException
+
 ## Version [8.4.0]
+
 - Added support for Taxonomy endpoints in the Management API
 - Added support for Taxonomy concepts in Entry and Asset metadata
 - Added new models for TaxonomyConcept and TaxonomyConceptScheme
 - Added methods for managing taxonomy concepts and concept schemes
 
 ## Version [1.2.0]
+
 - Adds method `CreateEntryForLocaleAsync` to the management client.
 
 ## Version [1.1.1]
+
 - Adds missing properties for the `SystemProperties` object.
 
 ## Version [1.1.0]
+
 - Adds convenience methods to `ContentfulManagementClient` for retrieveing, creating and updating entries without having to use `Entry<dynamic>`.
 
 ## Version [1.0.0]
+
 - Initial stable release on NetStandard 2.0

--- a/Contentful.AspNetCore/Contentful.AspNetCore.csproj
+++ b/Contentful.AspNetCore/Contentful.AspNetCore.csproj
@@ -3,7 +3,7 @@
     <Description>Official .NET SDK for the Contentful Content Delivery and Management API for ASP.NET core.</Description>
     <PackageId>contentful.aspnetcore</PackageId>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>8.4.0</VersionPrefix>
+    <VersionPrefix>8.4.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Contentful</Authors>
     <Copyright>Contentful GmbH.</Copyright>
@@ -13,10 +13,10 @@
     <PackageProjectUrl>https://github.com/contentful/contentful.net</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <Version>8.4.0</Version>
-    <AssemblyVersion>8.4.0.0</AssemblyVersion>
+    <Version>8.4.1</Version>
+    <AssemblyVersion>8.4.1.0</AssemblyVersion>
     <RepositoryUrl>https://github.com/contentful/contentful.net</RepositoryUrl>
-    <FileVersion>8.4.0.0</FileVersion>
+    <FileVersion>8.4.1.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.5\Contentful.AspNetCore.xml</DocumentationFile>
@@ -25,7 +25,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="contentful.csharp" Version="8.4.0" />
+    <PackageReference Include="contentful.csharp" Version="8.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />

--- a/Contentful.Core.Tests/ContentfulManagementClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulManagementClientTests.cs
@@ -2538,6 +2538,41 @@ namespace Contentful.Core.Tests
         }
 
         [Theory]
+        [InlineData("test-role-123", 42)]
+        [InlineData("another-role-456", 99)]
+        public async Task UpdateRoleShouldSetVersionHeader(string id, int version)
+        {
+            //Arrange
+            _handler.Response = GetResponseFromFile(@"SampleRole.json");
+
+            var role = new Role()
+            {
+                SystemProperties = new SystemProperties()
+                {
+                    Id = id,
+                    Version = version
+                },
+                Name = "Test Role",
+                Description = "Test role description"
+            };
+            
+            var versionHeader = "";
+            _handler.VerifyRequest = (HttpRequestMessage request) =>
+            {
+                if (request.Headers.TryGetValues("X-Contentful-Version", out var values))
+                {
+                    versionHeader = values.FirstOrDefault();
+                }
+            };
+
+            //Act
+            var res = await _client.UpdateRole(role);
+
+            //Assert
+            Assert.Equal(version.ToString(), versionHeader);
+        }
+
+        [Theory]
         [InlineData("09hfdh4-34")]
         [InlineData("643")]
         [InlineData("fdgs34")]

--- a/Contentful.Core/Contentful.Core.csproj
+++ b/Contentful.Core/Contentful.Core.csproj
@@ -4,7 +4,7 @@
     <PackageId>contentful.csharp</PackageId>
     <AssemblyTitle>contentful.net</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>8.4.0</VersionPrefix>
+    <VersionPrefix>8.4.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Contentful</Authors>
     <Copyright>Contentful GmbH.</Copyright>

--- a/Contentful.Core/ContentfulManagementClient.cs
+++ b/Contentful.Core/ContentfulManagementClient.cs
@@ -1440,11 +1440,12 @@ namespace Contentful.Core
             }
 
             var id = role.SystemProperties.Id;
+            var version = role.SystemProperties.Version;
 
             //Not allowed to post system properties
             role.SystemProperties = null;
 
-            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{id}", ConvertObjectToJsonStringContent(role), cancellationToken, null).ConfigureAwait(false);
+            using var res = await PutAsync($"{_baseUrl}{spaceId ?? _options.SpaceId}/roles/{id}", ConvertObjectToJsonStringContent(role), cancellationToken, version).ConfigureAwait(false);
 
             return await GetObjectFromResponse<Role>(res).ConfigureAwait(false);
         }


### PR DESCRIPTION
Updating a role expects that the version is passed in as a header