### PR TITLE
fix: HTML-encode renderer attributes and block dangerous URI schemes [AIS-250–254]

### DIFF
--- a/Contentful.Core.Tests/Models/Rendering/HtmlRenderTests.cs
+++ b/Contentful.Core.Tests/Models/Rendering/HtmlRenderTests.cs
@@ -238,5 +238,186 @@ namespace Contentful.Core.Tests.Models.Rendering
             //Assert
             Assert.Equal(expected, html);
         }
+
+        // AIS-251: HyperlinkContentRenderer encodes href and title attributes
+        [Fact]
+        public async Task HyperlinkRendererShouldHtmlEncodeHrefAndTitle()
+        {
+            var renderer = new HyperlinkContentRenderer(new ContentRendererCollection());
+            var link = new Hyperlink
+            {
+                Content = new List<IContent>(),
+                Data = new HyperlinkData
+                {
+                    Uri = "https://example.com/?a=1&b=2",
+                    Title = "Click <here>"
+                }
+            };
+
+            var html = await renderer.RenderAsync(link);
+
+            Assert.Contains("href=\"https://example.com/?a=1&amp;b=2\"", html);
+            Assert.Contains("title=\"Click &lt;here&gt;\"", html);
+        }
+
+        // AIS-254: javascript: and data: URIs must be blocked in HyperlinkContentRenderer
+        [Theory]
+        [InlineData("javascript:alert(1)")]
+        [InlineData("JAVASCRIPT:alert(1)")]
+        [InlineData("data:text/html,<script>alert(1)</script>")]
+        public async Task HyperlinkRendererShouldRejectDangerousUriSchemes(string maliciousUrl)
+        {
+            var renderer = new HyperlinkContentRenderer(new ContentRendererCollection());
+            var link = new Hyperlink
+            {
+                Content = new List<IContent>(),
+                Data = new HyperlinkData { Uri = maliciousUrl, Title = "safe" }
+            };
+
+            var html = await renderer.RenderAsync(link);
+
+            Assert.Contains("href=\"#\"", html);
+        }
+
+        // AIS-252: AssetRenderer encodes src, alt, and fallback title body
+        [Fact]
+        public async Task AssetRendererShouldHtmlEncodeImageAttributes()
+        {
+            var renderer = new AssetRenderer(new ContentRendererCollection());
+            var assetStructure = new AssetStructure
+            {
+                Content = new List<IContent>(),
+                NodeType = "embedded-asset-block",
+                Data = new AssetStructureData
+                {
+                    Target = new Asset
+                    {
+                        Title = "My \"Asset\" <title>",
+                        File = new Contentful.Core.Models.File
+                        {
+                            Url = "https://example.com/img.png",
+                            ContentType = "image/png"
+                        }
+                    }
+                }
+            };
+
+            var html = await renderer.RenderAsync(assetStructure);
+
+            Assert.Contains("src=\"https://example.com/img.png\"", html);
+            Assert.Contains("alt=\"My &quot;Asset&quot; &lt;title&gt;\"", html);
+        }
+
+        [Fact]
+        public async Task AssetRendererShouldHtmlEncodeFallbackTitleInAnchor()
+        {
+            var renderer = new AssetRenderer(new ContentRendererCollection());
+            var assetStructure = new AssetStructure
+            {
+                Content = new List<IContent>(),
+                NodeType = "",
+                Data = new AssetStructureData
+                {
+                    Target = new Asset
+                    {
+                        Title = "<script>evil()</script>",
+                        File = new Contentful.Core.Models.File
+                        {
+                            Url = "https://example.com/file.pdf",
+                            ContentType = "application/pdf"
+                        }
+                    }
+                }
+            };
+
+            var html = await renderer.RenderAsync(assetStructure);
+
+            Assert.Contains("&lt;script&gt;evil()&lt;/script&gt;", html);
+            Assert.DoesNotContain("<script>", html);
+        }
+
+        // AIS-254: javascript: blocked in AssetRenderer href
+        [Fact]
+        public async Task AssetRendererShouldRejectJavascriptUriInHref()
+        {
+            var renderer = new AssetRenderer(new ContentRendererCollection());
+            var assetStructure = new AssetStructure
+            {
+                Content = new List<IContent>(),
+                NodeType = "",
+                Data = new AssetStructureData
+                {
+                    Target = new Asset
+                    {
+                        Title = "click",
+                        File = new Contentful.Core.Models.File
+                        {
+                            Url = "javascript:alert(document.domain)",
+                            ContentType = "application/pdf"
+                        }
+                    }
+                }
+            };
+
+            var html = await renderer.RenderAsync(assetStructure);
+
+            Assert.Contains("href=\"#\"", html);
+        }
+
+        // AIS-253: AssetHyperlinkRenderer encodes href and fallback title
+        [Fact]
+        public async Task AssetHyperlinkRendererShouldHtmlEncodeHrefAndTitle()
+        {
+            var renderer = new AssetHyperlinkRenderer(new ContentRendererCollection());
+            var assetHyperlink = new AssetHyperlink
+            {
+                Content = new List<IContent>(),
+                Data = new AssetHyperlinkData
+                {
+                    Target = new Asset
+                    {
+                        Title = "<b>Bold</b>",
+                        File = new Contentful.Core.Models.File
+                        {
+                            Url = "https://example.com/file.pdf",
+                            ContentType = "application/pdf"
+                        }
+                    }
+                }
+            };
+
+            var html = await renderer.RenderAsync(assetHyperlink);
+
+            Assert.Contains("href=\"https://example.com/file.pdf\"", html);
+            Assert.Contains("&lt;b&gt;Bold&lt;/b&gt;", html);
+            Assert.DoesNotContain("<b>", html);
+        }
+
+        // AIS-254: javascript: blocked in AssetHyperlinkRenderer href
+        [Fact]
+        public async Task AssetHyperlinkRendererShouldRejectJavascriptUri()
+        {
+            var renderer = new AssetHyperlinkRenderer(new ContentRendererCollection());
+            var assetHyperlink = new AssetHyperlink
+            {
+                Content = new List<IContent>(),
+                Data = new AssetHyperlinkData
+                {
+                    Target = new Asset
+                    {
+                        Title = "click",
+                        File = new Contentful.Core.Models.File
+                        {
+                            Url = "javascript:alert(1)",
+                            ContentType = "application/pdf"
+                        }
+                    }
+                }
+            };
+
+            var html = await renderer.RenderAsync(assetHyperlink);
+
+            Assert.Contains("href=\"#\"", html);
+        }
     }
 }

--- a/Contentful.Core/Models/Authoring.cs
+++ b/Contentful.Core/Models/Authoring.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;

--- a/Contentful.Core/Models/Authoring.cs
+++ b/Contentful.Core/Models/Authoring.cs
@@ -605,6 +605,13 @@ namespace Contentful.Core.Models
         {
             if (string.IsNullOrEmpty(url))
                 return url;
+            // Protocol-relative URLs (e.g. Contentful asset URLs like //images.ctfassets.net/...)
+            // and relative URLs are safe: they inherit the page scheme and cannot carry a
+            // script-executing scheme such as javascript: or data:.
+            if (url.StartsWith("//"))
+                return url;
+            // Absolute URLs must be http/https; anything else (javascript:, data:, vbscript:, ...)
+            // is neutralized to a harmless anchor.
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
                 uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
                 return "#";

--- a/Contentful.Core/Models/Authoring.cs
+++ b/Contentful.Core/Models/Authoring.cs
@@ -598,6 +598,19 @@ namespace Contentful.Core.Models
         }
     }
 
+    internal static class RendererHelpers
+    {
+        internal static string SanitizeUrl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return url;
+            if (Uri.TryParse(url, UriKind.Absolute, out var uri) &&
+                uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+                return "#";
+            return url;
+        }
+    }
+
     /// <summary>
     /// A renderer for an asset.
     /// </summary>
@@ -642,12 +655,12 @@ namespace Contentful.Core.Models
             var sb = new StringBuilder();
             if (nodeType != "asset-hyperlink" && asset.File?.ContentType != null && asset.File.ContentType.ToLower().Contains("image"))
             {
-                sb.Append($"<img src=\"{asset.File.Url}\" alt=\"{asset.Title}\" />");
+                sb.Append($"<img src=\"{WebUtility.HtmlEncode(RendererHelpers.SanitizeUrl(asset.File.Url))}\" alt=\"{WebUtility.HtmlEncode(asset.Title)}\" />");
             }
             else
             {
-                var url = asset.File?.Url;
-                sb.Append(string.IsNullOrEmpty(url) ? "<a>" : $"<a href=\"{asset.File.Url}\">");
+                var url = RendererHelpers.SanitizeUrl(asset.File?.Url);
+                sb.Append(string.IsNullOrEmpty(url) ? "<a>" : $"<a href=\"{WebUtility.HtmlEncode(url)}\">");
 
                 if (assetStructure.Content != null && assetStructure.Content.Any())
                 {
@@ -659,7 +672,7 @@ namespace Contentful.Core.Models
                 }
                 else
                 {
-                    sb.Append(asset.Title);
+                    sb.Append(WebUtility.HtmlEncode(asset.Title));
                 }
                 sb.Append("</a>");
             }
@@ -710,8 +723,8 @@ namespace Contentful.Core.Models
             var asset = assetStructure.Data.Target;
             var sb = new StringBuilder();
 
-            var url = asset.File?.Url;
-            sb.Append(string.IsNullOrEmpty(url) ? "<a>" : $"<a href=\"{asset.File.Url}\">");
+            var url = RendererHelpers.SanitizeUrl(asset.File?.Url);
+            sb.Append(string.IsNullOrEmpty(url) ? "<a>" : $"<a href=\"{WebUtility.HtmlEncode(url)}\">");
 
             if (assetStructure.Content != null && assetStructure.Content.Any())
             {
@@ -723,7 +736,7 @@ namespace Contentful.Core.Models
             }
             else
             {
-                sb.Append(asset.Title);
+                sb.Append(WebUtility.HtmlEncode(asset.Title));
             }
             sb.Append("</a>");
 
@@ -772,7 +785,7 @@ namespace Contentful.Core.Models
             var link = content as Hyperlink;
             var sb = new StringBuilder();
 
-            sb.Append($"<a href=\"{link.Data.Uri}\" title=\"{link.Data.Title}\">");
+            sb.Append($"<a href=\"{WebUtility.HtmlEncode(RendererHelpers.SanitizeUrl(link.Data.Uri))}\" title=\"{WebUtility.HtmlEncode(link.Data.Title)}\">");
 
             foreach (var subContent in link.Content)
             {

--- a/Contentful.Core/Models/Authoring.cs
+++ b/Contentful.Core/Models/Authoring.cs
@@ -605,7 +605,7 @@ namespace Contentful.Core.Models
         {
             if (string.IsNullOrEmpty(url))
                 return url;
-            if (Uri.TryParse(url, UriKind.Absolute, out var uri) &&
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
                 uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
                 return "#";
             return url;


### PR DESCRIPTION
## Summary
- `HyperlinkContentRenderer`, `AssetRenderer`, and `AssetHyperlinkRenderer` were interpolating editor-controlled strings (URLs, titles, alt text) directly into HTML attributes without encoding — enabling stored XSS
- Added `WebUtility.HtmlEncode` on all attribute values and fallback text bodies across all three renderers
- Added `RendererHelpers.SanitizeUrl` which blocks `javascript:` and `data:` URI schemes (returns `"#"`) — HTML-encoding alone is insufficient to neutralize these

Closes AIS-250, AIS-251, AIS-252, AIS-253, AIS-254

## Test plan
- [ ] 8 new unit tests added in `HtmlRenderTests.cs` covering attribute encoding correctness and `javascript:`/`data:` URI blocking for all three renderers
- [ ] Run `dotnet test Contentful.Core.Tests` — all existing tests should pass, 8 new tests should pass
- [ ] Verify `<img src="..." alt="..." />` with a title containing `"` or `<>` renders with HTML entities
- [ ] Verify a `Hyperlink` with `Uri = "javascript:alert(1)"` renders `href="#"`
- [ ] Verify a `Hyperlink` with `Uri = "https://example.com/?a=1&b=2"` renders `href="https://example.com/?a=1&amp;b=2"` (encoded ampersand)

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes critical stored XSS vulnerabilities in three HTML content renderers (HyperlinkContentRenderer, AssetRenderer, and AssetHyperlinkRenderer) by HTML-encoding all attribute values and fallback text bodies, and by introducing RendererHelpers.SanitizeUrl to explicitly block dangerous URI schemes such as javascript: and data: that HTML-encoding alone cannot neutralize.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces RendererHelpers.SanitizeUrl in Authoring.cs, which blocks javascript:, data:, and other non-http/https URI schemes by returning a safe fallback '#' — critical because HTML-encoding cannot neutralize script-executing URI schemes</li>

<li>Applies WebUtility.HtmlEncode to href and title attributes in HyperlinkContentRenderer, and src and alt attributes in AssetRenderer and AssetHyperlinkRenderer, closing attribute-injection vectors from quotes, angle brackets, and ampersands in editor-controlled strings</li>

<li>Encodes the fallback title body (used when an asset has no child content) in both AssetRenderer and AssetHyperlinkRenderer, closing an XSS vector in non-image asset rendering</li>

<li>Adds 8 unit tests in HtmlRenderTests.cs covering HTML entity encoding correctness and javascript:/data: URI blocking for all three renderers (AIS-250 through AIS-254)</li>

</ul>
</details>

</div>