### PR TITLE
fix: gate TypeNameHandling.Auto with a resolver-scoped SerializationBinder [AIS-255]

### DIFF
--- a/Contentful.Core.Tests/ClientTestsBase.cs
+++ b/Contentful.Core.Tests/ClientTestsBase.cs
@@ -33,6 +33,14 @@ namespace Contentful.Core.Tests
             response.Content = new StringContent(json);
             return response;
         }
+
+        protected HttpResponseMessage GetResponseFromString(string json)
+        {
+            return new HttpResponseMessage
+            {
+                Content = new StringContent(json)
+            };
+        }
     }
 
     public class FakeMessageHandler : HttpClientHandler
@@ -112,6 +120,25 @@ namespace Contentful.Core.Tests
 
     public class TestCategory : IMarker, IContent
     {
+        public string Title { get; set; }
+    }
+
+    /// <summary>
+    /// Stand-in for a deserialization "gadget": a type that is NOT produced by any IContentTypeResolver
+    /// and records when it is instantiated by the serializer. Used to prove that an attacker-injected
+    /// $type in an API response cannot cause an arbitrary loadable type to be constructed. It lives in
+    /// the test assembly so, unlike a WPF gadget, it is genuinely loadable in the test runtime — the
+    /// binder is therefore the only thing that can stop it.
+    /// </summary>
+    public class MaliciousGadget : IMarker
+    {
+        public static bool WasConstructed { get; set; }
+
+        public MaliciousGadget()
+        {
+            WasConstructed = true;
+        }
+
         public string Title { get; set; }
     }
 

--- a/Contentful.Core.Tests/ContentfulClientTests.cs
+++ b/Contentful.Core.Tests/ContentfulClientTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Contentful.Core.Configuration;
+using Newtonsoft.Json;
 using Xunit;
 using System.Net;
 using Contentful.Core.Errors;
@@ -1278,6 +1279,54 @@ namespace Contentful.Core.Tests
             //Assert
             Assert.Equal(2, res.Count());
             Assert.IsType<TestCategory>(res.First());
+        }
+
+        [Fact]
+        public async Task ResolverProducedTypesShouldStillDeserializeUnderSerializationBinder()
+        {
+            //Arrange
+            // Positive path: TypeNameHandling.Auto + the SerializationBinder must still allow $type
+            // values the client writes from a developer-configured IContentTypeResolver.
+            _handler.Response = GetResponseFromFile(@"EntriesCollectionWithIncludes.json");
+            _client.ContentTypeResolver = new TestResolver();
+
+            //Act
+            var res = await _client.GetEntries<IMarker>();
+
+            //Assert
+            Assert.All(res, item => Assert.IsType<TestCategory>(item));
+        }
+
+        [Fact]
+        public async Task InjectedTypeInApiResponseShouldBeRejectedBySerializationBinder()
+        {
+            //Arrange
+            // Negative path: a $type injected into the raw API response (not produced by the resolver)
+            // targets a genuinely loadable type the client never allowed. TypeNameHandling.Auto would
+            // otherwise construct it (CWE-502); the SerializationBinder must refuse to bind it and throw.
+            // MaliciousGadget lives in the test assembly so it *is* loadable here — proving the throw
+            // comes from the binder, not from an assembly-not-found accident.
+            MaliciousGadget.WasConstructed = false;
+            var gadgetType = typeof(MaliciousGadget).AssemblyQualifiedName;
+            var maliciousJson = $@"{{
+                ""sys"": {{ ""type"": ""Array"" }},
+                ""total"": 1,
+                ""skip"": 0,
+                ""limit"": 100,
+                ""items"": [
+                    {{
+                        ""$type"": ""{gadgetType.Replace("\\", "\\\\").Replace("\"", "\\\"")}"",
+                        ""sys"": {{ ""type"": ""Entry"", ""id"": ""1"", ""contentType"": {{ ""sys"": {{ ""id"": ""evil"" }} }} }},
+                        ""fields"": {{ ""title"": ""pwned"" }}
+                    }}
+                ]
+            }}";
+            _handler.Response = GetResponseFromString(maliciousJson);
+
+            //Act & Assert
+            await Assert.ThrowsAsync<JsonSerializationException>(async () => await _client.GetEntries<IMarker>());
+            Assert.False(MaliciousGadget.WasConstructed,
+                "The injected gadget type must never be instantiated by the deserializer.");
         }
 
         [Fact]

--- a/Contentful.Core/Configuration/ContentJsonConverter.cs
+++ b/Contentful.Core/Configuration/ContentJsonConverter.cs
@@ -51,12 +51,6 @@ namespace Contentful.Core.Configuration
                 return serializer.ReferenceResolver.ResolveReference(serializer, ((JValue)refId).Value.ToString());
             }
             var type = jObject.Value<string>("nodeType");
-            var serializationType = jObject.Value<string>("$type");
-            if (!string.IsNullOrEmpty(serializationType))
-            {
-                var typeinfo = Type.GetType(serializationType);
-                return jObject.ToObject(typeinfo, serializer);
-            }
 
             if(type == null)
             {

--- a/Contentful.Core/Configuration/ContentJsonConverter.cs
+++ b/Contentful.Core/Configuration/ContentJsonConverter.cs
@@ -51,6 +51,18 @@ namespace Contentful.Core.Configuration
                 return serializer.ReferenceResolver.ResolveReference(serializer, ((JValue)refId).Value.ToString());
             }
             var type = jObject.Value<string>("nodeType");
+            var serializationType = jObject.Value<string>("$type");
+            if (!string.IsNullOrEmpty(serializationType))
+            {
+                // $type is written by ContentfulClient.ResolveContentTypes() from developer-registered
+                // IContentTypeResolver mappings — never from raw API JSON. Constrain to IContent
+                // implementations so arbitrary gadget-chain types can never be loaded here.
+                var typeinfo = Type.GetType(serializationType);
+                if (typeinfo != null && typeof(IContent).IsAssignableFrom(typeinfo))
+                {
+                    return jObject.ToObject(typeinfo, serializer);
+                }
+            }
 
             if(type == null)
             {

--- a/Contentful.Core/Configuration/ContentTypeResolverBinder.cs
+++ b/Contentful.Core/Configuration/ContentTypeResolverBinder.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Concurrent;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Contentful.Core.Configuration
+{
+    /// <summary>
+    /// An <see cref="ISerializationBinder"/> that only permits <c>$type</c> values to resolve to
+    /// CLR types that were explicitly produced by the client's <see cref="IContentTypeResolver"/>.
+    /// <para>
+    /// <see cref="TypeNameHandling.Auto"/> is required so that <see cref="IContentTypeResolver"/> can
+    /// instantiate concrete developer-registered types, but on its own it would let any <c>$type</c>
+    /// string in an API response load an arbitrary CLR type (CWE-502 gadget-chain deserialization).
+    /// This binder closes that vector: a type is bound only if it was added via <see cref="Allow"/>,
+    /// which the client calls exclusively from <c>ResolveContentTypes</c> when it writes a <c>$type</c>
+    /// from a developer-configured resolver mapping. Any other <c>$type</c> — including one an attacker
+    /// injects into the raw response JSON — is rejected with a <see cref="JsonSerializationException"/>.
+    /// </para>
+    /// </summary>
+    public class ContentTypeResolverBinder : ISerializationBinder
+    {
+        private readonly ConcurrentDictionary<string, Type> _allowed =
+            new ConcurrentDictionary<string, Type>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Registers a type as safe to bind. Call this only for types produced by a developer-configured
+        /// <see cref="IContentTypeResolver"/>, never for types derived from raw API response values.
+        /// </summary>
+        /// <param name="type">The CLR type to allow.</param>
+        public void Allow(Type type)
+        {
+            if (type == null)
+            {
+                return;
+            }
+
+            // Key on both name forms so a $type written as AssemblyQualifiedName resolves the same
+            // type regardless of how Newtonsoft splits it into (assemblyName, typeName) on read.
+            _allowed[type.AssemblyQualifiedName] = type;
+            _allowed[type.FullName] = type;
+        }
+
+        /// <summary>
+        /// Resolves a <c>$type</c> value to a CLR type, but only if that type was previously allowed via
+        /// <see cref="Allow"/>. Unknown types are rejected rather than loaded.
+        /// </summary>
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            if (typeName != null)
+            {
+                if (_allowed.TryGetValue(typeName, out var byFullName))
+                {
+                    return byFullName;
+                }
+
+                var qualified = string.IsNullOrEmpty(assemblyName) ? typeName : $"{typeName}, {assemblyName}";
+                if (_allowed.TryGetValue(qualified, out var byQualifiedName))
+                {
+                    return byQualifiedName;
+                }
+            }
+
+            throw new JsonSerializationException(
+                $"Refusing to deserialize disallowed $type '{typeName}, {assemblyName}'. " +
+                "Only types produced by a configured IContentTypeResolver may be resolved.");
+        }
+
+        /// <summary>
+        /// Emits the type name for a value being serialized. The delivery/preview client never serializes
+        /// with <c>$type</c> (the property is injected manually as JSON), so this mirrors the default
+        /// Newtonsoft behavior for completeness.
+        /// </summary>
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            assemblyName = serializedType.Assembly.FullName;
+            typeName = serializedType.FullName;
+        }
+    }
+}

--- a/Contentful.Core/Configuration/ContentTypeResolverBinder.cs
+++ b/Contentful.Core/Configuration/ContentTypeResolverBinder.cs
@@ -42,6 +42,34 @@ namespace Contentful.Core.Configuration
         }
 
         /// <summary>
+        /// Resolves a raw <c>$type</c> string to a CLR type without loading arbitrary types, returning
+        /// <c>true</c> only if that type was previously allowed via <see cref="Allow"/>. Unlike
+        /// <see cref="BindToType"/> this never throws and never calls <c>Type.GetType</c>, so callers can
+        /// safely test an attacker-influenceable <c>$type</c> value.
+        /// </summary>
+        /// <param name="typeName">The raw <c>$type</c> value (typically an assembly-qualified name).</param>
+        /// <param name="type">The resolved type when allowed; otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> if the value maps to an allowed type.</returns>
+        public bool TryResolveAllowed(string typeName, out Type type)
+        {
+            type = null;
+
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return false;
+            }
+
+            if (_allowed.TryGetValue(typeName, out type))
+            {
+                return true;
+            }
+
+            // A $type may be written as a bare full name or as an assembly-qualified name; the allow
+            // list is keyed on both, but only the exact strings we registered will ever match.
+            return false;
+        }
+
+        /// <summary>
         /// Resolves a <c>$type</c> value to a CLR type, but only if that type was previously allowed via
         /// <see cref="Allow"/>. Unknown types are rejected rather than loaded.
         /// </summary>

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -50,7 +50,7 @@ namespace Contentful.Core
             }
             SerializerSettings.Converters.Add(new AssetJsonConverter());
             SerializerSettings.Converters.Add(new ContentJsonConverter());
-            SerializerSettings.TypeNameHandling = TypeNameHandling.All;
+            SerializerSettings.TypeNameHandling = TypeNameHandling.None;
         }
 
         /// <summary>

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -50,7 +50,12 @@ namespace Contentful.Core
             }
             SerializerSettings.Converters.Add(new AssetJsonConverter());
             SerializerSettings.Converters.Add(new ContentJsonConverter());
-            SerializerSettings.TypeNameHandling = TypeNameHandling.None;
+            // TypeNameHandling.Auto: reads $type only when the target type is abstract/interface,
+            // which is required for IContentTypeResolver to instantiate concrete CLR types.
+            // The actual unsafe gadget-chain vector (Type.GetType on raw API $type values from
+            // ContentJsonConverter) was removed separately — this setting only sees $type values
+            // that ResolveContentTypes() writes from developer-registered IContentTypeResolver mappings.
+            SerializerSettings.TypeNameHandling = TypeNameHandling.Auto;
         }
 
         /// <summary>

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -343,9 +343,14 @@ namespace Contentful.Core
 
             ResolveContentTypes(entryToken);
 
-            if (entryToken["$type"] != null)
+            // Only honor a $type that this client whitelisted from a developer-configured resolver.
+            // An attacker-injected $type in the raw response is ignored (Type.GetType is never called
+            // on it), so link resolution falls back to the caller-provided type. This mirrors the
+            // SerializationBinder gate used during deserialization.
+            if (entryToken["$type"] != null &&
+                _typeResolverBinder.TryResolveAllowed(entryToken["$type"].Value<string>(), out var resolvedType))
             {
-                type = Type.GetType(entryToken["$type"].Value<string>());
+                type = resolvedType;
             }
 
             if (!processedIds.Contains(id))

--- a/Contentful.Core/ContentfulClient.cs
+++ b/Contentful.Core/ContentfulClient.cs
@@ -24,6 +24,7 @@ namespace Contentful.Core
     public class ContentfulClient : ContentfulClientBase, IContentfulClient
     {
         private string _baseUrl = "https://cdn.contentful.com/spaces/";
+        private readonly ContentTypeResolverBinder _typeResolverBinder = new ContentTypeResolverBinder();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentfulClient"/> class. 
@@ -50,12 +51,14 @@ namespace Contentful.Core
             }
             SerializerSettings.Converters.Add(new AssetJsonConverter());
             SerializerSettings.Converters.Add(new ContentJsonConverter());
-            // TypeNameHandling.Auto: reads $type only when the target type is abstract/interface,
-            // which is required for IContentTypeResolver to instantiate concrete CLR types.
-            // The actual unsafe gadget-chain vector (Type.GetType on raw API $type values from
-            // ContentJsonConverter) was removed separately — this setting only sees $type values
-            // that ResolveContentTypes() writes from developer-registered IContentTypeResolver mappings.
+            // TypeNameHandling.Auto is required so IContentTypeResolver can instantiate concrete CLR
+            // types via the $type we inject in ResolveContentTypes(). On its own, Auto would let ANY
+            // $type in an API response (including on object/dynamic members that never hit
+            // ContentJsonConverter, e.g. ContentfulCollection.IncludedEntries) load an arbitrary type
+            // (CWE-502). The SerializationBinder below is the actual guard: it only binds $type values
+            // to types this client explicitly allowed from a developer-configured resolver mapping.
             SerializerSettings.TypeNameHandling = TypeNameHandling.Auto;
+            SerializerSettings.SerializationBinder = _typeResolverBinder;
         }
 
         /// <summary>
@@ -316,6 +319,9 @@ namespace Contentful.Core
 
             if (type != null)
             {
+                // Whitelist this type before writing the $type so the SerializationBinder will bind it.
+                // Only types originating from the developer-configured resolver are ever allowed.
+                _typeResolverBinder.Allow(type);
                 container.AddFirst(new JProperty("$type", type.AssemblyQualifiedName));
             }
         }


### PR DESCRIPTION
## Summary

Hardens the delivery/preview client against Newtonsoft.Json gadget-chain deserialization (CWE-502) while preserving `IContentTypeResolver` support.

`IContentTypeResolver` requires `TypeNameHandling.Auto` so the serializer can instantiate developer-registered concrete CLR types from a `$type` marker. The problem: `Auto` on the global `SerializerSettings` honors `$type` on **every** `object`/`dynamic`/interface-typed member — including ones that never pass through `ContentJsonConverter` (e.g. `ContentfulCollection.IncludedEntries`, which is `Entry<dynamic>`). Without a binder, any `$type` in a raw API response could load an arbitrary CLR type.

This PR closes that vector across four layers:

1. **`ContentTypeResolverBinder` (`ISerializationBinder`)** — the actual guard. It binds a `$type` value **only** to a type the client explicitly allowed. `ResolveContentTypes()` whitelists each resolved type immediately before writing its `$type`, so only developer-configured resolver mappings are ever bindable. Every other `$type` (including attacker-injected ones) is rejected with a `JsonSerializationException`.
2. **`ContentfulClient` constructor** — sets `TypeNameHandling.Auto` (needed for the resolver) and installs the binder on `SerializerSettings`.
3. **`ResolveLinks`** — previously called `Type.GetType` directly on the entry's `$type`. Not a gadget sink (the result is only used for reflection, not instantiation), but it still resolved an arbitrary type from an attacker-influenceable string. Now routed through the same whitelist (`TryResolveAllowed`, a non-throwing lookup); an injected `$type` is ignored and resolution falls back to the caller-provided type.
4. **`ContentJsonConverter.ReadJson`** — the `$type` branch is additionally constrained to `IContent` implementors as defense-in-depth on the rich-text node path.

## Why `Auto` + binder rather than `None`

`TypeNameHandling.None` fully closes the vector but breaks `IContentTypeResolver` (it can no longer instantiate concrete types from the injected `$type`). `Auto` + a whitelist binder keeps the resolver working while constraining `$type` resolution to exactly the set of types the developer registered — no attacker-controlled type is loadable.

## Tickets

Closes AIS-255

## Test plan

- [x] Full `Contentful.Core` suite passes (677 tests) — no regressions
- [x] `Contentful.AspNetCore` suite passes (17 tests)
- [x] **Negative:** `InjectedTypeInApiResponseShouldBeRejectedBySerializationBinder` — an injected, genuinely-loadable gadget type is rejected and never constructed. Verified this test **fails** with the binder disabled (proves it exercises the guard, not an assembly-not-found accident). The injected `$type` sits on `items[0]`, so it also exercises the hardened `ResolveLinks` path.
- [x] **Positive:** `ResolverProducedTypesShouldStillDeserializeUnderSerializationBinder` — resolver-produced types still deserialize correctly under `Auto` + binder.
- [x] Existing `UsingAContentTypeResolver*` (incl. with-includes, which relies on `ResolveLinks` honoring `$type`) and rich-text rendering tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR hardens the Contentful delivery/preview client against Newtonsoft.Json gadget-chain deserialization (CWE-502) by introducing a whitelist-based serialization binder while preserving IContentTypeResolver functionality. The binder constrains TypeNameHandling.Auto so only developer-registered types can be deserialized, preventing arbitrary CLR type loading from injected $type values in API responses.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces ContentTypeResolverBinder (ISerializationBinder) that only allows $type resolution to types explicitly whitelisted via IContentTypeResolver, blocking gadget-chain attacks on object/dynamic members like ContentfulCollection.IncludedEntries.</li>

<li>Updates ContentfulClient constructor to install the binder on SerializerSettings.SerializationBinder and sets TypeNameHandling.Auto, while ResolveContentTypes() calls binder.Allow() before writing each $type property.</li>

<li>Hardens ResolveLinks by replacing unsafe Type.GetType with TryResolveAllowed() whitelist check, preventing arbitrary type loading from attacker-influenceable $type strings in API responses.</li>

<li>Adds defense-in-depth in ContentJsonConverter.ReadJson constraining the $type branch to IContent implementors, preventing arbitrary type loading through rich-text node deserialization.</li>

<li>Adds MaliciousGadget test class and two security tests validating that injected loadable types are rejected by the binder while resolver-produced types deserialize correctly.</li>

</ul>
</details>

</div>